### PR TITLE
Introduces AUP - Acceptable Use Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-This repository tracks all versions of the Exoscale Terms and Conditions.
+This repository tracks all versions of the Exoscale contractual documents such as:
+
+* Terms and Conditions.
+* End User Service Agreement
+* Acceptable Use Policy
+
 The goal is for customers and observers to facilitate and track changes
 with full transparency.
 
@@ -7,6 +12,6 @@ The repository is structured as follow:
 * Current version: [terms.markdown](terms.markdown)
 * Previous version: [terms-previous.markdown](terms-previous.markdown)
 
-An archive folder is also published to track older differences from the files.
+The GIT versioning system makes it easier to track older differences from the files.
 
 The terms and conditions are published under the [exoscale website](https://www.exoscale.com/terms/)

--- a/aup-previous.markdown
+++ b/aup-previous.markdown
@@ -13,7 +13,7 @@ that are not allowed on the Exoscale Services. The examples in
 this policy are not exhaustive. Exoscale may modify the AUP at any time
 and inform it's clients accordingly. If you violate the AUP, authorize
 or assist others to do so, Exoscale is entitled to suspend or terminate
-your account on the Exposcale Services as described in the
+your account on the Exoscale Services as described in the
 Exoscale Terms and Conditions or Exoscale End User Service Agreement. 
 
 Capitalized terms used in this AUP and not otherwise defined herein shall have the meaning given in the Exoscale Terms and Conditions or Exoscale End User Service Agreement.

--- a/aup-previous.markdown
+++ b/aup-previous.markdown
@@ -1,0 +1,154 @@
+**EXOSCALE ACCEPTABLE USE POLICY (EUSA) **
+
+Applicable starting October 12th, 2020
+
+[Previous version](https://github.com/exoscale/terms/blob/master/aup-previous.markdown)
+[Compare](https://github.com/exoscale/terms/commits/master)
+
+# 1. Introduction
+
+This Acceptable Use Policy ("AUP") describes prohibited use of the
+services provided by Akenes SA (hereafter "Exoscale") and activities
+that are not allowed on the Exoscale Services. The examples in
+this policy are not exhaustive. Exoscale may modify the AUP at any time
+and inform it's clients accordingly. If you violate the AUP, authorize
+or assist others to do so, Exoscale is entitled to suspend or terminate
+your account on the Exposcale Services as described in the
+Exoscale Terms and Conditions or Exoscale End User Service Agreement. 
+
+Capitalized terms used in this AUP and not otherwise defined herein shall have the meaning given in the Exoscale Terms and Conditions or Exoscale End User Service Agreement.
+
+# 2. No Illegal, Harmful or Offensive Use or Content
+
+You may not use, or encourage, promote, facilitate or instruct others to
+use, the Exoscale services or website for any illegal, harmful or
+offensive use, or to transmit, store, display, distribute or otherwise
+make available content that is illegal, harmful, or offensive.
+
+Prohibited activities or content include but are not limited to:
+
+-   Illegal Activities. Any illegal activities, for example, including disseminating,
+    promoting or facilitating child pornography or otherwise
+    unlawfully exploits persons under 18 years of age.
+
+-   Harmful or Fraudulent Activities. Activities that may be harmful to others, our operations or
+    reputation, including offering or disseminating fraudulent goods,
+    services, schemes, or promotions (e.g., make-money-fast schemes,
+    ponzi and pyramid schemes, phishing, or pharming), or engaging in
+    other deceptive practices.
+
+-   Infringing Content. Content that infringes or misappropriates the intellectual property
+    or proprietary rights of others.
+
+-   Offensive Content. Content that is defamatory, obscene, abusive, invasive of privacy,
+    or otherwise objectionable, including content that constitutes
+    child pornography, relates to bestiality, or depicts
+    non-consensual sex acts.
+
+-   Harmful Content. Content or other computer technology that may damage, interfere
+    with, surreptitiously intercept, or expropriate any system,
+    program, or data, including viruses, Trojan horses, worms, time
+    bombs, or cancelbots.
+
+-   Violent Content. Publishing, transmitting or storing any content or links to any
+    content that is excessively violent, incites violence, threatens
+    violence, contains harassing content or hate speech, creates a
+    risk to a person\'s safety or health, or public safety or health,
+    compromises national security or interferes with an investigation
+    by law enforcement.
+
+-   Deceptive Content. Content that is unfair or deceptive under the consumer protection
+    laws of any jurisdiction.
+
+# 3. No Security Violations
+
+You may not use the Service to violate the security or integrity of any
+network, computer or communications system, software application, or
+network or computing device (each, a "System"). Prohibited activities
+include:
+
+-   Unauthorized Access. Accessing or using any System without permission, including
+    attempting to probe, scan, or test the vulnerability of a System
+    or to breach any security or authentication measures used by a
+    System.
+
+-   Interception. Monitoring of data or traffic on a System without permission.
+
+-   Falsification of Origin. Forging TCP-IP packet headers, e-mail 
+    headers, or any part of a message describing its origin or route.
+    This prohibition does not include the use of aliases or anonymous 
+    remailers.
+
+# 4. No Network Abuse 
+
+You may not make network connections to any users, hosts, or networks
+unless you have permission to communicate with them. Prohibited
+activities include:
+
+-   Monitoring or Crawling. Monitoring or crawling of a System that impairs or disrupts the
+    System being monitored or crawled.
+
+-   Denial of Service (DoS) - Distributed (DDOS) or not. Inundating a target with communications 
+    requests so the target either cannot respond to legitimate 
+    traffic or responds so slowly that it becomes ineffective.
+    
+-   Covert Usage. Distributing software that covertly gathers or transmits information about a user.
+-   Unauthorized Access. Unauthorized access to or use of data, Systems or networks, including any attempt to probe, scan or test the vulnerability of a System or to breach security or authentication measures without express authorization of the owner of the System.
+
+-   Intentional Interference. Interfering with the proper functioning of any System, including any
+    deliberate attempt to overload a system by mail bombing, news
+    bombing, broadcast attacks, or flooding techniques.
+
+-   Operation of Certain Network Services. Operating network services like open proxies, open mail relays, or
+    open recursive domain name servers.
+
+-   Avoiding System Restrictions. Using manual or electronic means to avoid any use limitations placed
+    on a System, such as access and storage restrictions.
+    
+-   Withholding Identity. Any activity intended to withhold or cloak identity or contact information, including the omission, deletion, forgery or misreporting of any transmission or identification information, such as return mailing and IP addresses.
+    
+-   Spam. Any action which directly or indirectly results in any 
+    of our IP space being listed on any abuse database (i.e. Spamhaus).
+
+# 5. No Email or Other Message Abuse
+
+You will not distribute, publish, send, or facilitate the sending of
+unsolicited mass e-mail or other unsolicited messages, promotions,
+advertising, or solicitations (like "spam"). You will not alter or
+obscure mail headers or assume a sender's identity without the sender's
+explicit permission. You will not collect replies to messages sent from
+another internet service provider if those messages violate this Policy
+or the acceptable use policy of that provider.
+
+# 6. Email policy
+
+You must comply with the laws and regulations applicable to bulk or
+commercial email in your jurisdiction. In addition, you will comply with
+the following restrictions.
+
+- You must have a Privacy Policy posted for each domain associated with the mailing;
+- You must have the means to track anonymous complaints; and
+- You must not obscure the source of your e-mail in any manner.
+- You must post an email address for complaints (such as abuse@yourdomain.com) in a conspicuous place on any website associated with the email, and you must promptly respond to messages sent to that address;
+- Your intended recipients have given their consent to receive e-mail via some affirmative means, such as an opt-in procedure, and you can produce the evidence of such consent within 72 hours of receipt of a request by the recipient or Exoscale;
+- You must use reasonable means to ensure that the person giving consent is the owner of the e-mail address for which the consent is given;
+- You must include the recipient's e-mail address in the body of the message or in the "TO" line of the e-mail. 
+- You must honor revocations of consent and notify recipients of the same;
+
+These policies apply to messages sent using the Service, or to messages sent from any System by you or any person on your behalf that directly or indirectly refer the recipient to a site hosted via the Service. In addition, you may not use a third party e-mail service that does not practice similar procedures for all its customers. These requirements apply to distribution lists created by third parties to the same extent as if you created the list.
+
+# Third Party Conduct
+
+You are responsible for violations of this AUP by anyone using your Service with your permission or on an unauthorized basis as a result of your failure to use reasonable security precautions. Your use of the Service to assist another person in an activity that would violate this AUP if performed by you is a violation of the AUP.
+
+You must use reasonable efforts to secure any device or network within your control against being used in breach of the applicable laws against spam and unsolicited email, including where appropriate by the installation of antivirus software, firewall software and operating system and application software patches and updates. Our right to suspend or terminate your Service applies even if a breach is committed unintentionally or without your authorization, including through a Trojan horse or virus.
+
+# Consequences of Violation of AUP
+
+If you breach the AUP we may suspend or terminate your Service in accordance with the Agreement. We may intercept or block any content or traffic belonging to you or to users where the Service is being used unlawfully or not in accordance with this AUP.
+
+No credit will be available under the Service Level Agreement for interruptions of service resulting from any AUP violation.
+
+# Reporting of Violations of this AUP
+
+If you become aware of any violation of this AUP, you will immediately notify us and provide us with assistance, as requested, to stop or remedy the violation. To report any violation of this AUP, please contact us at abuse@exoscale.com.

--- a/aup.markdown
+++ b/aup.markdown
@@ -5,7 +5,7 @@ Applicable starting October 12th, 2020
 [Previous version](https://github.com/exoscale/terms/blob/master/aup-previous.markdown)
 [Compare](https://github.com/exoscale/terms/commits/master)
 
-# 1. Introduction
+## 1. Introduction
 
 This Acceptable Use Policy ("AUP") describes prohibited use of the
 services provided by Akenes SA (hereafter "Exoscale") and activities
@@ -16,9 +16,11 @@ or assist others to do so, Exoscale is entitled to suspend or terminate
 your account on the Exposcale Services as described in the
 Exoscale Terms and Conditions or Exoscale End User Service Agreement. 
 
-Capitalized terms used in this AUP and not otherwise defined herein shall have the meaning given in the Exoscale Terms and Conditions or Exoscale End User Service Agreement.
+Capitalized terms used in this AUP and not otherwise defined herein
+shall have the meaning given in the Exoscale Terms and Conditions 
+or Exoscale End User Service Agreement.
 
-# 2. No Illegal, Harmful or Offensive Use or Content
+## 2. No Illegal, Harmful or Offensive Use or Content
 
 You may not use, or encourage, promote, facilitate or instruct others to
 use, the Exoscale services or website for any illegal, harmful or
@@ -60,7 +62,7 @@ Prohibited activities or content include but are not limited to:
 -   Deceptive Content. Content that is unfair or deceptive under the consumer protection
     laws of any jurisdiction.
 
-# 3. No Security Violations
+## 3. No Security Violations
 
 You may not use the Service to violate the security or integrity of any
 network, computer or communications system, software application, or
@@ -79,7 +81,7 @@ include:
     This prohibition does not include the use of aliases or anonymous 
     remailers.
 
-# 4. No Network Abuse 
+## 4. No Network Abuse 
 
 You may not make network connections to any users, hosts, or networks
 unless you have permission to communicate with them. Prohibited
@@ -93,24 +95,30 @@ activities include:
     traffic or responds so slowly that it becomes ineffective.
     
 -   Covert Usage. Distributing software that covertly gathers or transmits information about a user.
--   Unauthorized Access. Unauthorized access to or use of data, Systems or networks, including any attempt to probe, scan or test the vulnerability of a System or to breach security or authentication measures without express authorization of the owner of the System.
+
+-   Unauthorized Access. Unauthorized access to or use of data, Systems or networks, 
+    including any attempt to probe, scan or test the vulnerability of a System or 
+    to breach security or authentication measures without express authorization of 
+    the owner of the System.
 
 -   Intentional Interference. Interfering with the proper functioning of any System, including any
     deliberate attempt to overload a system by mail bombing, news
     bombing, broadcast attacks, or flooding techniques.
 
--   Operation of Certain Network Services. Operating network services like open proxies, open mail relays, or
-    open recursive domain name servers.
+-   Operation of Certain Network Services. Operating network services like open 
+    proxies, open mail relays, or open recursive domain name servers.
 
--   Avoiding System Restrictions. Using manual or electronic means to avoid any use limitations placed
-    on a System, such as access and storage restrictions.
+-   Avoiding System Restrictions. Using manual or electronic means to 
+    avoid any use limitations placed on a System, such as access and storage restrictions.
     
--   Withholding Identity. Any activity intended to withhold or cloak identity or contact information, including the omission, deletion, forgery or misreporting of any transmission or identification information, such as return mailing and IP addresses.
+-   Withholding Identity. Any activity intended to withhold or cloak identity 
+    or contact information, including the omission, deletion, forgery or misreporting 
+    of any transmission or identification information, such as return mailing and IP addresses.
     
 -   Spam. Any action which directly or indirectly results in any 
     of our IP space being listed on any abuse database (i.e. Spamhaus).
 
-# 5. No Email or Other Message Abuse
+## 5. No Email or Other Message Abuse
 
 You will not distribute, publish, send, or facilitate the sending of
 unsolicited mass e-mail or other unsolicited messages, promotions,
@@ -120,7 +128,7 @@ explicit permission. You will not collect replies to messages sent from
 another internet service provider if those messages violate this Policy
 or the acceptable use policy of that provider.
 
-# 6. Email policy
+## 6. Email policy
 
 You must comply with the laws and regulations applicable to bulk or
 commercial email in your jurisdiction. In addition, you will comply with
@@ -137,18 +145,18 @@ the following restrictions.
 
 These policies apply to messages sent using the Service, or to messages sent from any System by you or any person on your behalf that directly or indirectly refer the recipient to a site hosted via the Service. In addition, you may not use a third party e-mail service that does not practice similar procedures for all its customers. These requirements apply to distribution lists created by third parties to the same extent as if you created the list.
 
-# Third Party Conduct
+## 7. Third Party Conduct
 
 You are responsible for violations of this AUP by anyone using your Service with your permission or on an unauthorized basis as a result of your failure to use reasonable security precautions. Your use of the Service to assist another person in an activity that would violate this AUP if performed by you is a violation of the AUP.
 
 You must use reasonable efforts to secure any device or network within your control against being used in breach of the applicable laws against spam and unsolicited email, including where appropriate by the installation of antivirus software, firewall software and operating system and application software patches and updates. Our right to suspend or terminate your Service applies even if a breach is committed unintentionally or without your authorization, including through a Trojan horse or virus.
 
-# Consequences of Violation of AUP
+## 8. Consequences of Violation of AUP
 
 If you breach the AUP we may suspend or terminate your Service in accordance with the Agreement. We may intercept or block any content or traffic belonging to you or to users where the Service is being used unlawfully or not in accordance with this AUP.
 
 No credit will be available under the Service Level Agreement for interruptions of service resulting from any AUP violation.
 
-# Reporting of Violations of this AUP
+## 8. Reporting of Violations of this AUP
 
 If you become aware of any violation of this AUP, you will immediately notify us and provide us with assistance, as requested, to stop or remedy the violation. To report any violation of this AUP, please contact us at abuse@exoscale.com.

--- a/aup.markdown
+++ b/aup.markdown
@@ -1,0 +1,154 @@
+**EXOSCALE ACCEPTABLE USE POLICY (EUSA) **
+
+Applicable starting October 12th, 2020
+
+[Previous version](https://github.com/exoscale/terms/blob/master/aup-previous.markdown)
+[Compare](https://github.com/exoscale/terms/commits/master)
+
+# 1. Introduction
+
+This Acceptable Use Policy ("AUP") describes prohibited use of the
+services provided by Akenes SA (hereafter "Exoscale") and activities
+that are not allowed on the Exoscale Services. The examples in
+this policy are not exhaustive. Exoscale may modify the AUP at any time
+and inform it's clients accordingly. If you violate the AUP, authorize
+or assist others to do so, Exoscale is entitled to suspend or terminate
+your account on the Exposcale Services as described in the
+Exoscale Terms and Conditions or Exoscale End User Service Agreement. 
+
+Capitalized terms used in this AUP and not otherwise defined herein shall have the meaning given in the Exoscale Terms and Conditions or Exoscale End User Service Agreement.
+
+# 2. No Illegal, Harmful or Offensive Use or Content
+
+You may not use, or encourage, promote, facilitate or instruct others to
+use, the Exoscale services or website for any illegal, harmful or
+offensive use, or to transmit, store, display, distribute or otherwise
+make available content that is illegal, harmful, or offensive.
+
+Prohibited activities or content include but are not limited to:
+
+-   Illegal Activities. Any illegal activities, for example, including disseminating,
+    promoting or facilitating child pornography or otherwise
+    unlawfully exploits persons under 18 years of age.
+
+-   Harmful or Fraudulent Activities. Activities that may be harmful to others, our operations or
+    reputation, including offering or disseminating fraudulent goods,
+    services, schemes, or promotions (e.g., make-money-fast schemes,
+    ponzi and pyramid schemes, phishing, or pharming), or engaging in
+    other deceptive practices.
+
+-   Infringing Content. Content that infringes or misappropriates the intellectual property
+    or proprietary rights of others.
+
+-   Offensive Content. Content that is defamatory, obscene, abusive, invasive of privacy,
+    or otherwise objectionable, including content that constitutes
+    child pornography, relates to bestiality, or depicts
+    non-consensual sex acts.
+
+-   Harmful Content. Content or other computer technology that may damage, interfere
+    with, surreptitiously intercept, or expropriate any system,
+    program, or data, including viruses, Trojan horses, worms, time
+    bombs, or cancelbots.
+
+-   Violent Content. Publishing, transmitting or storing any content or links to any
+    content that is excessively violent, incites violence, threatens
+    violence, contains harassing content or hate speech, creates a
+    risk to a person\'s safety or health, or public safety or health,
+    compromises national security or interferes with an investigation
+    by law enforcement.
+
+-   Deceptive Content. Content that is unfair or deceptive under the consumer protection
+    laws of any jurisdiction.
+
+# 3. No Security Violations
+
+You may not use the Service to violate the security or integrity of any
+network, computer or communications system, software application, or
+network or computing device (each, a "System"). Prohibited activities
+include:
+
+-   Unauthorized Access. Accessing or using any System without permission, including
+    attempting to probe, scan, or test the vulnerability of a System
+    or to breach any security or authentication measures used by a
+    System.
+
+-   Interception. Monitoring of data or traffic on a System without permission.
+
+-   Falsification of Origin. Forging TCP-IP packet headers, e-mail 
+    headers, or any part of a message describing its origin or route.
+    This prohibition does not include the use of aliases or anonymous 
+    remailers.
+
+# 4. No Network Abuse 
+
+You may not make network connections to any users, hosts, or networks
+unless you have permission to communicate with them. Prohibited
+activities include:
+
+-   Monitoring or Crawling. Monitoring or crawling of a System that impairs or disrupts the
+    System being monitored or crawled.
+
+-   Denial of Service (DoS) - Distributed (DDOS) or not. Inundating a target with communications 
+    requests so the target either cannot respond to legitimate 
+    traffic or responds so slowly that it becomes ineffective.
+    
+-   Covert Usage. Distributing software that covertly gathers or transmits information about a user.
+-   Unauthorized Access. Unauthorized access to or use of data, Systems or networks, including any attempt to probe, scan or test the vulnerability of a System or to breach security or authentication measures without express authorization of the owner of the System.
+
+-   Intentional Interference. Interfering with the proper functioning of any System, including any
+    deliberate attempt to overload a system by mail bombing, news
+    bombing, broadcast attacks, or flooding techniques.
+
+-   Operation of Certain Network Services. Operating network services like open proxies, open mail relays, or
+    open recursive domain name servers.
+
+-   Avoiding System Restrictions. Using manual or electronic means to avoid any use limitations placed
+    on a System, such as access and storage restrictions.
+    
+-   Withholding Identity. Any activity intended to withhold or cloak identity or contact information, including the omission, deletion, forgery or misreporting of any transmission or identification information, such as return mailing and IP addresses.
+    
+-   Spam. Any action which directly or indirectly results in any 
+    of our IP space being listed on any abuse database (i.e. Spamhaus).
+
+# 5. No Email or Other Message Abuse
+
+You will not distribute, publish, send, or facilitate the sending of
+unsolicited mass e-mail or other unsolicited messages, promotions,
+advertising, or solicitations (like "spam"). You will not alter or
+obscure mail headers or assume a sender's identity without the sender's
+explicit permission. You will not collect replies to messages sent from
+another internet service provider if those messages violate this Policy
+or the acceptable use policy of that provider.
+
+# 6. Email policy
+
+You must comply with the laws and regulations applicable to bulk or
+commercial email in your jurisdiction. In addition, you will comply with
+the following restrictions.
+
+- You must have a Privacy Policy posted for each domain associated with the mailing;
+- You must have the means to track anonymous complaints; and
+- You must not obscure the source of your e-mail in any manner.
+- You must post an email address for complaints (such as abuse@yourdomain.com) in a conspicuous place on any website associated with the email, and you must promptly respond to messages sent to that address;
+- Your intended recipients have given their consent to receive e-mail via some affirmative means, such as an opt-in procedure, and you can produce the evidence of such consent within 72 hours of receipt of a request by the recipient or Exoscale;
+- You must use reasonable means to ensure that the person giving consent is the owner of the e-mail address for which the consent is given;
+- You must include the recipient's e-mail address in the body of the message or in the "TO" line of the e-mail. 
+- You must honor revocations of consent and notify recipients of the same;
+
+These policies apply to messages sent using the Service, or to messages sent from any System by you or any person on your behalf that directly or indirectly refer the recipient to a site hosted via the Service. In addition, you may not use a third party e-mail service that does not practice similar procedures for all its customers. These requirements apply to distribution lists created by third parties to the same extent as if you created the list.
+
+# Third Party Conduct
+
+You are responsible for violations of this AUP by anyone using your Service with your permission or on an unauthorized basis as a result of your failure to use reasonable security precautions. Your use of the Service to assist another person in an activity that would violate this AUP if performed by you is a violation of the AUP.
+
+You must use reasonable efforts to secure any device or network within your control against being used in breach of the applicable laws against spam and unsolicited email, including where appropriate by the installation of antivirus software, firewall software and operating system and application software patches and updates. Our right to suspend or terminate your Service applies even if a breach is committed unintentionally or without your authorization, including through a Trojan horse or virus.
+
+# Consequences of Violation of AUP
+
+If you breach the AUP we may suspend or terminate your Service in accordance with the Agreement. We may intercept or block any content or traffic belonging to you or to users where the Service is being used unlawfully or not in accordance with this AUP.
+
+No credit will be available under the Service Level Agreement for interruptions of service resulting from any AUP violation.
+
+# Reporting of Violations of this AUP
+
+If you become aware of any violation of this AUP, you will immediately notify us and provide us with assistance, as requested, to stop or remedy the violation. To report any violation of this AUP, please contact us at abuse@exoscale.com.

--- a/aup.markdown
+++ b/aup.markdown
@@ -13,7 +13,7 @@ that are not allowed on the Exoscale Services. The examples in
 this policy are not exhaustive. Exoscale may modify the AUP at any time
 and inform it's clients accordingly. If you violate the AUP, authorize
 or assist others to do so, Exoscale is entitled to suspend or terminate
-your account on the Exposcale Services as described in the
+your account on the Exoscale Services as described in the
 Exoscale Terms and Conditions or Exoscale End User Service Agreement. 
 
 Capitalized terms used in this AUP and not otherwise defined herein

--- a/eusa.markdown
+++ b/eusa.markdown
@@ -12,6 +12,7 @@ SLA, and all documents referenced within those documents (together, the
 provisions your Subscription.
 
 Applicable starting January 16th, 2019
+
 [Previous version](https://github.com/exoscale/terms/blob/master/eusa-previous.markdown)
 [Compare](https://github.com/exoscale/terms/commits/master/eusa.markdown)
 

--- a/eusa.markdown
+++ b/eusa.markdown
@@ -13,7 +13,7 @@ provisions your Subscription.
 
 Applicable starting January 16th, 2019
 [Previous version](https://github.com/exoscale/terms/blob/master/eusa-previous.markdown)
-[Compare](https://github.com/exoscale/terms/commits/master)
+[Compare](https://github.com/exoscale/terms/commits/master/eusa.markdown)
 
 ## 1. Definitions
 

--- a/terms.markdown
+++ b/terms.markdown
@@ -5,7 +5,7 @@ individually as a "**Party**" and collectively, as the "**Parties**".
 
 Applicable starting January 16th, 2019
 [Previous version](https://github.com/exoscale/terms/blob/master/terms-previous.markdown)
-[Compare](https://github.com/exoscale/terms/commits/master)
+[Compare](https://github.com/exoscale/terms/commits/master/terms.markdown)
 
 ## 1. Definitions
 

--- a/terms.markdown
+++ b/terms.markdown
@@ -4,6 +4,7 @@ Computing Services. Supplier and Client are hereinafter referred to
 individually as a "**Party**" and collectively, as the "**Parties**".
 
 Applicable starting January 16th, 2019
+
 [Previous version](https://github.com/exoscale/terms/blob/master/terms-previous.markdown)
 [Compare](https://github.com/exoscale/terms/commits/master/terms.markdown)
 


### PR DESCRIPTION
This PR adds the first version of AUP to our legal suite in order to be more precise in our Terms and Conditions under chapter regarding Misuse about the General Rules of the Internet.