### PR TITLE
add DPA to the terms tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-This repository tracks all versions of the Exoscale Terms and Conditions.
+This repository tracks all versions of the Exoscale Terms and Conditions
+and other legally binding documents:
+
+* Terms and Conditions
+* End User Service Agreement
+* Data Processing Agreement
+
 The goal is for customers and observers to facilitate and track changes
 with full transparency.
 
@@ -7,6 +13,7 @@ The repository is structured as follow:
 * Current version: [terms.markdown](terms.markdown)
 * Previous version: [terms-previous.markdown](terms-previous.markdown)
 
-An archive folder is also published to track older differences from the files.
+An archive folder is also published to track older differences from the files
+but using git comparison between commit is the preferred method.
 
 The terms and conditions are published under the [exoscale website](https://www.exoscale.com/terms/)

--- a/dpa-previous.markdown
+++ b/dpa-previous.markdown
@@ -1,0 +1,217 @@
+This Data Processing Addendum, hereafter "DPA", is an Agreement between
+Akenes SA hereafter "Exoscale" and the client hereafter "Client". This
+Addendum is either an extension to the Exoscale Terms and Conditions
+available at <https://www.exoscale.com/terms/>, or the EUSA, as the case
+maybe, (each hereafter T&C) as updated from time to time between Client
+and Exoscale, when GDPR applies to your use of the Services to process
+Client Data.
+
+## 1. Definitions
+
+GDPR means Regulation (EU) 2016/679 of the European Parliament and of
+the Council of 27 April 2016 on the protection of natural persons with
+regard to the processing of personal data and on the free movement of
+such data, and repealing Directive 95/46/EC (General Data Protection
+Regulation).
+
+The terms "Personal Data", "Data Subject", "Processing", "Controller",
+"Processor", "Union" and "Member State" as used in this Data Processing
+Addendum have the meanings given in the GDPR.
+
+Unless otherwise defined in this DPA, all capitalised terms used shall
+have the meanings given to them in the T&C.
+
+## 2. Details of Processing
+
+Subject matter: the subject matter of the data processing under this DPA
+is Client Data.
+
+Duration: throughout the Term of the Services being provided by Exoscale
+to Client. Term of Services under this DPA is determined by the Client
+or exceptionally by Exoscale via provisions of the T&C.
+
+Nature and Purpose of the Processing: compute, storage, and such other
+services as described in the Website and initiated by Client. The
+purpose is the provision of the Services initiated by Client.
+
+Type of personal data: personal data uploaded to the Services under
+Client's Exoscale accounts.
+
+Categories of data subjects: the data subjects include without
+limitation: Client's customers, employees, suppliers, and end-users.
+
+## 3. Obligations and Rights of the Controller
+
+If European Data Protection Legislation applies to the processing of
+Client's data, the parties acknowledge and agree that Exoscale is a
+Processor of Client's data under European Data Protection Legislation,
+that Client is a Controller under European Data Protection Legislation
+(unless when Client acts as a Processor, in which case Exoscale is a
+sub-Processor) and that the parties complies with their obligations
+under applicable European Data Protection Legislation with respect to
+the processing of Personal Data.
+
+## 4. Client Instructions
+
+By entering into this DPA, the parties agree that the DPA constitutes
+Client's documented instructions regarding Exoscale's processing of
+Personal Data. Exoscale only processes Client Data to the extent that is
+necessary to provide the Services.
+
+## 5. Confidentiality
+
+Exoscale does not access, use, or share Client Data to any third party,
+except when this access, use or sharing is necessary to provide the
+Services, or as required to comply with law enforcement requests.
+
+## 6. Security of Processing
+
+Exoscale implements and maintains appropriate technical and
+organizational security measures to protect Client Data against
+accidental destruction, alteration or access. These measures take into
+account the state of the art and include (a) the pseudonymisation and
+encryption of Client Data; (b) the ability to ensure the ongoing
+confidentiality, integrity, availability and resilience of processing
+systems and services; (c) the ability to restore the availability and
+access to personal data in a timely manner in the event of a physical or
+technical incident; (d) a process for regularly testing, assessing and
+evaluating the effectiveness of technical and organisational measures
+for ensuring the security of the processing. Exoscale may assess and
+improve security measures at regular intervals, provided that these
+improvements lead to an increased level of security for providing the
+Services. Exoscale assists the Client in ensuring compliance with the
+obligations pursuant to Articles 32 to 36 of the GDPR given the nature
+of processing and the information available to Exoscale.
+
+## 7. Processors
+
+Exoscale maintains a list of its sub-Processors at
+[https://www.exoscale.com/privacy/#data-processors](https://www.exoscale.com/privacy/#data-processors).
+Exoscale informs the Client of any intended changes concerning the
+addition or replacement of other Processors at least 30 days in advance.
+Exoscale makes sure Data Processing Addendums are in place with its
+sub-Processors to ensure compliance with the GDPR. If the Client objects
+the addition or replacement of a sub-Processor, they may terminate the
+services as described in the T&C.
+
+## 8. Data Subject Rights
+
+Exoscale assists the Client for the fulfilment of their obligation to
+respond to requests for exercising the data subject's rights as laid
+down in Chapter III of the GDPR: (a) right of access by the data
+subject, (b) right to rectification, (c) right to erasure, (d) right to
+restriction of processing, and (e) right to data portability. Upon
+receiving such requests from data subjects, Exoscale uses commercially
+reasonable efforts to forward requests to the Client.
+
+## 9. Deletion and Return
+
+Client's right to data return is described in Section 13 of the T&C. In
+addition, Exoscale deletes all the personal data after the end of the
+provision of Services and deletes existing copies unless Union or Member
+State law requires storage of the personal data.
+
+## 10. Audit rights
+
+Exoscale allows for and contributes to audits, including inspections, to
+demonstrate compliance with the obligations and measures described in
+this DPA conducted by the Client or another auditor mandated by the
+Client by means of random checks during business hours, which are
+ordinarily to be announced 1 month in prior. In order to carry out an
+inspection, the Client shall send a detailed audit / control plan to
+Exoscale at least two weeks before the scheduled date of the audit,
+indicating the scope, duration of the audit and the start date of the
+audit. Exoscale shall review the audit/control plan and provide the
+Client with any material concerns and questions, such as information
+requests, that may affect the security, privacy or employment policy of
+the Exoscale. In any case, Exoscale cooperates cooperatively with the
+Client to agree on a final audit/control plan. Exoscale may claim
+remuneration for enabling Client inspections. Proof of the
+implementation of technical and organizational measures to comply with
+the obligations arising from this contract may be provided by:
+
+a)  Certification according to an approved certification procedure in
+    accordance with Art.42 GDPR;
+b)  Current auditor's certificates, reports or excerpts from reports
+    provided by independent bodies (e.g. auditor, Data Protection
+    Officer, IT security department, data privacy auditor, quality
+    auditor)
+c)  A relevant certification by IT security or data protection auditing
+    (e.g. according to IT Baseline Protection certification developed by
+    the [German](https://en.wikipedia.org/wiki/Germany) Federal Office
+    for Security in Information Technology (BSI)) or ISO/IEC).
+d)  Annual reports by Exoscale
+
+## Schedule 1: Exoscale Security Controls
+
+### Confidentiality 
+
+**Physical Access Control**: physical access to facilities is guarded by
+24/7 staff performing identity controls, as well as automated mechanisms
+including fenced doors with biometric checks, CCTV recording, and motion
+detection.
+
+**Electronic access control**: strong password policy, encryption of
+at-rest data, use of state-of-the art software security mechanisms.
+
+**Internal Access Control**: data access requests to Exoscale systems
+are made according to an authorizations scheme implementing need-based
+rights of access. All system access events are logged within Exoscale's
+visibility platform.
+
+**Isolation Control**: strong logical separation is enforced between
+Data Subjects.
+
+**Pseudonymization**: Personal data is processed in a way allowing that
+the data cannot be associated with a specific Data Subject without the
+assistance of additional information, stored separately.
+
+### Integrity
+
+**Data Transfer Control**: Personal Data is only transferred in an
+encrypted way to ensure no unauthorized reading, copying, changes or
+deletion happens during the transfer.
+
+**Data Entry Control**: data entry events are logged within Exoscale's
+visibility platform.
+
+### Availability and Resilience
+
+**Availability control**:
+
+* Physical: redundant power, network and storage mitigate against
+  hardware issues leading to data unavailability or loss.
+* Logical: firewalling provides strong systems isolation. Online and
+  offline backups are made to prevent accidental or wilful destruction
+  or loss.
+
+**Rapid recovery**: in the event of a physical or technical incident,
+Exoscale keeps the ability to restore the availability and access to
+personal data in a timely manner.
+
+### Procedures for regular testing, assessment and evaluation
+
+**Data Protection Management**: Exoscale reviews on a yearly basis 1)
+its record of activity that inventories the processing of personal data,
+and 2) its Data Access response procedures.
+
+**Incident Response Management**: Exoscale carries yearly assessments of
+incident response scenarios, including data breach and data recovery
+procedures.
+
+**Data Protection by Design and by Default**: Exoscale processes data
+while ensuring the processing is done with the highest level of privacy
+protection:
+
+* Only a minimal set of data is processed, stored, or transferred over
+  the wire.
+* Storage period is the shortest possible for the given data
+  processed.
+* Access is as restricted as possible.
+* Encryption is used for all data access workloads.
+* Pseudonymization is generalized in the processing of Personal Data.
+
+**Order or Contact Control**: data processors are subject to clear and
+unambiguous contractual arrangements, formalized order management,
+strict controls on the selection of the Service Provider, as well as
+regular supervisory follow-up checks.

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -1,0 +1,219 @@
+This Data Processing Addendum, hereafter "DPA", is an Agreement between
+Akenes SA hereafter "Exoscale" and the client hereafter "Client". This
+Addendum is either an extension to the Exoscale Terms and Conditions
+available at <https://www.exoscale.com/terms/>, or the EUSA, as the case
+maybe, (each hereafter T&C) as updated from time to time between Client
+and Exoscale, when GDPR applies to your use of the Services to process
+Client Data.
+
+Applicable starting July 21st, 2021
+[Previous version](https://github.com/exoscale/terms/blob/master/dpa-previous.markdown)
+[Compare](https://github.com/exoscale/terms/commits/master)
+
+## 1. Definitions
+
+GDPR means Regulation (EU) 2016/679 of the European Parliament and of
+the Council of 27 April 2016 on the protection of natural persons with
+regard to the processing of personal data and on the free movement of
+such data, and repealing Directive 95/46/EC (General Data Protection
+Regulation).
+
+The terms "Personal Data", "Data Subject", "Processing", "Controller",
+"Processor", "Union" and "Member State" as used in this Data Processing
+Addendum have the meanings given in the GDPR.
+
+Unless otherwise defined in this DPA, all capitalised terms used shall
+have the meanings given to them in the T&C.
+
+## 2. Details of Processing
+
+Subject matter: the subject matter of the data processing under this DPA
+is Client Data.
+
+Duration: throughout the Term of the Services being provided by Exoscale
+to Client. Term of Services under this DPA is determined by the Client
+or exceptionally by Exoscale via provisions of the T&C.
+
+Nature and Purpose of the Processing: compute, storage, and such other
+services as described in the Website and initiated by Client. The
+purpose is the provision of the Services initiated by Client.
+
+Type of personal data: personal data uploaded to the Services under
+Client's Exoscale accounts.
+
+Categories of data subjects: the data subjects include without
+limitation: Client's customers, employees, suppliers, and end-users.
+
+## 3. Obligations and Rights of the Controller
+
+If European Data Protection Legislation applies to the processing of
+Client's data, the parties acknowledge and agree that Exoscale is a
+Processor of Client's data under European Data Protection Legislation,
+that Client is a Controller under European Data Protection Legislation
+(unless when Client acts as a Processor, in which case Exoscale is a
+sub-Processor) and that the parties complies with their obligations
+under applicable European Data Protection Legislation with respect to
+the processing of Personal Data.
+
+## 4. Client Instructions
+
+By entering into this DPA, the parties agree that the DPA constitutes
+Client's documented instructions regarding Exoscale's processing of
+Personal Data. Exoscale only processes Client Data to the extent that is
+necessary to provide the Services.
+
+## 5. Confidentiality
+
+Exoscale does not access, use, or share Client Data to any third party,
+except when this access, use or sharing is necessary to provide the
+Services, or as required to comply with law enforcement requests.
+
+## 6. Security of Processing
+
+Exoscale implements and maintains appropriate technical and
+organizational security measures to protect Client Data against
+accidental destruction, alteration or access. These measures take into
+account the state of the art and include (a) the pseudonymisation and
+encryption of Client Data; (b) the ability to ensure the ongoing
+confidentiality, integrity, availability and resilience of processing
+systems and services; (c) the ability to restore the availability and
+access to personal data in a timely manner in the event of a physical or
+technical incident; (d) a process for regularly testing, assessing and
+evaluating the effectiveness of technical and organisational measures
+for ensuring the security of the processing. Exoscale may assess and
+improve security measures at regular intervals, provided that these
+improvements lead to an increased level of security for providing the
+Services. Exoscale assists the Client in ensuring compliance with the
+obligations pursuant to Articles 32 to 36 of the GDPR given the nature
+of processing and the information available to Exoscale.
+
+## 7. Processors
+
+Exoscale maintains a list of its sub-Processors at
+[https://www.exoscale.com/privacy/#data-processors](https://www.exoscale.com/privacy/#data-processors).
+Exoscale informs the Client of any intended changes concerning the
+addition or replacement of other Processors at least 30 days in advance.
+Exoscale makes sure Data Processing Addendums are in place with its
+sub-Processors to ensure compliance with the GDPR and our security/data protection policies. If the Client objects the addition or replacement of a sub-Processor,
+they may terminate the services as described in the T&C.
+
+## 8. Data Subject Rights
+
+Exoscale assists the Client for the fulfilment of their obligation to
+respond to requests for exercising the data subject's rights as laid
+down in Chapter III of the GDPR: (a) right of access by the data
+subject, (b) right to rectification, (c) right to erasure, (d) right to
+restriction of processing, and (e) right to data portability. Upon
+receiving such requests from data subjects, Exoscale uses commercially
+reasonable efforts to forward requests to the Client.
+
+## 9. Deletion and Return
+
+Client's right to data return is described in [Section 13 of the T&C](https://www.exoscale.com/terms). In addition, Exoscale deletes all the personal data after
+the end of the provision of Services and deletes existing copies unless
+Union or Member State law requires storage of the personal data.
+
+## 10. Audit rights
+
+Exoscale allows for and contributes to audits, including inspections, to
+demonstrate compliance with the obligations and measures described in
+this DPA conducted by the Client or another auditor mandated by the
+Client by means of random checks during business hours, which are
+ordinarily to be announced 1 month in prior. In order to carry out an
+inspection, the Client shall send a detailed audit / control plan to
+Exoscale at least two weeks before the scheduled date of the audit,
+indicating the scope, duration of the audit and the start date of the
+audit. Exoscale shall review the audit/control plan and provide the
+Client with any material concerns and questions, such as information
+requests, that may affect the security, privacy or employment policy of
+the Exoscale. In any case, Exoscale cooperates cooperatively with the
+Client to agree on a final audit/control plan. Exoscale may claim
+remuneration for enabling Client inspections. Proof of the
+implementation of technical and organizational measures to comply with
+the obligations arising from this contract may be provided by:
+
+a)  Certification according to an approved certification procedure in
+    accordance with Art.42 GDPR;
+b)  Current auditor's certificates, reports or excerpts from reports
+    provided by independent bodies (e.g. auditor, Data Protection
+    Officer, IT security department, data privacy auditor, quality
+    auditor)
+c)  A relevant certification by IT security or data protection auditing
+    (e.g. according to IT Baseline Protection certification developed by
+    the [German](https://en.wikipedia.org/wiki/Germany) Federal Office
+    for Security in Information Technology (BSI)) or ISO/IEC).
+d)  Annual reports by Exoscale
+
+## Schedule 1: Exoscale Security Controls
+
+### Confidentiality 
+
+**Physical Access Control**: physical access to facilities is guarded by
+24/7 staff performing identity controls, as well as automated mechanisms
+including fenced doors with biometric checks, CCTV recording, and motion
+detection.
+
+**Electronic access control**: strong password policy, encryption of
+at-rest data, use of state-of-the art software security mechanisms.
+
+**Internal Access Control**: data access requests to Exoscale systems
+are made according to an authorizations scheme implementing need-based
+rights of access. All system access events are logged within Exoscale's
+visibility platform.
+
+**Isolation Control**: strong logical separation is enforced between
+Data Subjects.
+
+**Pseudonymization**: Personal data is processed in a way allowing that
+the data cannot be associated with a specific Data Subject without the
+assistance of additional information, stored separately.
+
+### Integrity
+
+**Data Transfer Control**: Personal Data is only transferred in an
+encrypted way to ensure no unauthorized reading, copying, changes or
+deletion happens during the transfer.
+
+**Data Entry Control**: data entry events are logged within Exoscale's
+visibility platform.
+
+### Availability and Resilience
+
+**Availability control**:
+
+* Physical: redundant power, network and storage mitigate against
+  hardware issues leading to data unavailability or loss.
+* Logical: firewalling provides strong systems isolation. Online and
+  offline backups are made to prevent accidental or wilful destruction
+  or loss.
+
+**Rapid recovery**: in the event of a physical or technical incident,
+Exoscale keeps the ability to restore the availability and access to
+personal data in a timely manner.
+
+### Procedures for regular testing, assessment and evaluation
+
+**Data Protection Management**: Exoscale reviews on a yearly basis 1)
+its record of activity that inventories the processing of personal data,
+and 2) its Data Access response procedures.
+
+**Incident Response Management**: Exoscale carries yearly assessments of
+incident response scenarios, including data breach and data recovery
+procedures.
+
+**Data Protection by Design and by Default**: Exoscale processes data
+while ensuring the processing is done with the highest level of privacy
+protection:
+
+* Only a minimal set of data is processed, stored, or transferred over
+  the wire.
+* Storage period is the shortest possible for the given data
+  processed.
+* Access is as restricted as possible.
+* Encryption is used for all data access workloads.
+* Pseudonymization is generalized in the processing of Personal Data.
+
+**Order or Contact Control**: data processors are subject to clear and
+unambiguous contractual arrangements, formalized order management,
+strict controls on the selection of the Service Provider, as well as
+regular supervisory follow-up checks.


### PR DESCRIPTION
This change intends to use the same process for the Data Processing Agreement tracking under GDPR regulations. This will make it easier for customers, prospects, partners or any other third party to track changes.