### PR TITLE
DPA v3.0

### DIFF
--- a/dpa-previous.markdown
+++ b/dpa-previous.markdown
@@ -6,6 +6,11 @@ maybe, (each hereafter T&C) as updated from time to time between Client
 and Exoscale, when GDPR applies to your use of the Services to process
 Client Data.
 
+Applicable starting September 1st, 2021 and binding at Client acceptance
+date as stored in the legal section of the Exoscale Portal of the Client.
+[Previous version](https://github.com/exoscale/terms/blob/master/dpa-previous.markdown)
+[Compare](https://github.com/exoscale/terms/commits/master)
+
 ## 1. Definitions
 
 GDPR means Regulation (EU) 2016/679 of the European Parliament and of
@@ -18,7 +23,7 @@ The terms "Personal Data", "Data Subject", "Processing", "Controller",
 "Processor", "Union" and "Member State" as used in this Data Processing
 Addendum have the meanings given in the GDPR.
 
-Unless otherwise defined in this DPA, all capitalised terms used shall
+Unless otherwise defined in this DPA, all capitalized terms used shall
 have the meanings given to them in the T&C.
 
 ## 2. Details of Processing
@@ -30,8 +35,9 @@ Duration: throughout the Term of the Services being provided by Exoscale
 to Client. Term of Services under this DPA is determined by the Client
 or exceptionally by Exoscale via provisions of the T&C.
 
-Nature and Purpose of the Processing: compute, storage, and such other
-services as described in the Website and initiated by Client. The
+Nature and Purpose of the Processing: compute, storage, and platform
+services as described in the Website and initiated by Client excluding
+third party services available from the Exoscale Marketplace. The
 purpose is the provision of the Services initiated by Client.
 
 Type of personal data: personal data uploaded to the Services under
@@ -58,11 +64,25 @@ Client's documented instructions regarding Exoscale's processing of
 Personal Data. Exoscale only processes Client Data to the extent that is
 necessary to provide the Services.
 
+The Processor may suspend the implementation of the instruction until
+it has been confirmed or changed by the client in writing.
+
+The Processor shall immediately inform the controller if, in its opinion, an
+instruction infringes applicable data protection regulations or other Union
+or Member State data protection provisions. The Processor may suspend the
+implementation of the instruction until it has been confirmed or changed by
+the client in writing. The Processor may refuse to execute instructions that are obviously in
+breach of data protection law at any time.
+
 ## 5. Confidentiality
 
 Exoscale does not access, use, or share Client Data to any third party,
 except when this access, use or sharing is necessary to provide the
 Services, or as required to comply with law enforcement requests.
+
+Exoscale ensures that the persons authorized to process personal data
+have committed themselves to confidentiality or are under an appropriate
+statutory obligation of confidentiality.
 
 ## 6. Security of Processing
 
@@ -75,7 +95,7 @@ confidentiality, integrity, availability and resilience of processing
 systems and services; (c) the ability to restore the availability and
 access to personal data in a timely manner in the event of a physical or
 technical incident; (d) a process for regularly testing, assessing and
-evaluating the effectiveness of technical and organisational measures
+evaluating the effectiveness of technical and organizational measures
 for ensuring the security of the processing. Exoscale may assess and
 improve security measures at regular intervals, provided that these
 improvements lead to an increased level of security for providing the
@@ -85,14 +105,14 @@ of processing and the information available to Exoscale.
 
 ## 7. Processors
 
-Exoscale maintains a list of its sub-Processors at
+Exoscale maintains a list of its sub-Processors per Service at
 [https://www.exoscale.com/privacy/#data-processors](https://www.exoscale.com/privacy/#data-processors).
 Exoscale informs the Client of any intended changes concerning the
 addition or replacement of other Processors at least 30 days in advance.
 Exoscale makes sure Data Processing Addendums are in place with its
-sub-Processors to ensure compliance with the GDPR. If the Client objects
-the addition or replacement of a sub-Processor, they may terminate the
-services as described in the T&C.
+sub-Processors to ensure compliance with the GDPR and our security/data
+protection policies. If the Client objects the addition or replacement
+of a sub-Processor, they may terminate the services as described in the T&C.
 
 ## 8. Data Subject Rights
 
@@ -106,10 +126,10 @@ reasonable efforts to forward requests to the Client.
 
 ## 9. Deletion and Return
 
-Client's right to data return is described in Section 13 of the T&C. In
-addition, Exoscale deletes all the personal data after the end of the
-provision of Services and deletes existing copies unless Union or Member
-State law requires storage of the personal data.
+Client's right to data return is described in Section 13 of the T&C.
+In addition, Exoscale deletes all the personal data after
+the end of the provision of Services and deletes existing copies unless
+Union or Member State law requires storage of the personal data.
 
 ## 10. Audit rights
 
@@ -130,21 +150,21 @@ remuneration for enabling Client inspections. Proof of the
 implementation of technical and organizational measures to comply with
 the obligations arising from this contract may be provided by:
 
-a)  Certification according to an approved certification procedure in
-    accordance with Art.42 GDPR;
-b)  Current auditor's certificates, reports or excerpts from reports
-    provided by independent bodies (e.g. auditor, Data Protection
-    Officer, IT security department, data privacy auditor, quality
-    auditor)
-c)  A relevant certification by IT security or data protection auditing
-    (e.g. according to IT Baseline Protection certification developed by
-    the [German](https://en.wikipedia.org/wiki/Germany) Federal Office
-    for Security in Information Technology (BSI)) or ISO/IEC).
-d)  Annual reports by Exoscale
+a) Certification according to an approved certification procedure in
+accordance with Art.42 GDPR;
+b) Current auditor's certificates, reports or excerpts from reports
+provided by independent bodies (e.g. auditor, Data Protection
+Officer, IT security department, data privacy auditor, quality
+auditor)
+c) A relevant certification by IT security or data protection auditing
+(e.g. according to IT Baseline Protection certification developed by
+the [German](https://en.wikipedia.org/wiki/Germany) Federal Office
+for Security in Information Technology (BSI)) or ISO/IEC).
+d) Annual reports by Exoscale
 
 ## Schedule 1: Exoscale Security Controls
 
-### Confidentiality 
+### Confidentiality
 
 **Physical Access Control**: physical access to facilities is guarded by
 24/7 staff performing identity controls, as well as automated mechanisms
@@ -179,9 +199,9 @@ visibility platform.
 
 **Availability control**:
 
-* Physical: redundant power, network and storage mitigate against
+- Physical: redundant power, network and storage mitigate against
   hardware issues leading to data unavailability or loss.
-* Logical: firewalling provides strong systems isolation. Online and
+- Logical: firewalling provides strong systems isolation. Online and
   offline backups are made to prevent accidental or wilful destruction
   or loss.
 
@@ -203,13 +223,13 @@ procedures.
 while ensuring the processing is done with the highest level of privacy
 protection:
 
-* Only a minimal set of data is processed, stored, or transferred over
+- Only a minimal set of data is processed, stored, or transferred over
   the wire.
-* Storage period is the shortest possible for the given data
+- Storage period is the shortest possible for the given data
   processed.
-* Access is as restricted as possible.
-* Encryption is used for all data access workloads.
-* Pseudonymization is generalized in the processing of Personal Data.
+- Access is as restricted as possible.
+- Encryption is used for all data access workloads.
+- Pseudonymization is generalized in the processing of Personal Data.
 
 **Order or Contact Control**: data processors are subject to clear and
 unambiguous contractual arrangements, formalized order management,

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -1,237 +1,127 @@
 This Data Processing Addendum, hereafter "DPA", is an Agreement between
-Akenes SA hereafter "Exoscale" and the client hereafter "Client". This
-Addendum is either an extension to the Exoscale Terms and Conditions
+Akenes SA hereafter "Exoscale" (referred to as the "**Processor**") and the client 
+hereafter "Client" (referred to as the "**Company**"). 
+This Addendum is either an extension to the Exoscale Terms and Conditions
 available at <https://www.exoscale.com/terms/>, or the EUSA, as the case
 maybe, (each hereafter T&C) as updated from time to time between Client
 and Exoscale, when GDPR applies to your use of the Services to process
 Client Data.
 
-Applicable starting September 1st, 2021 and binding at Client acceptance
+Applicable starting Decemeber 1st, 2024 and binding at Client acceptance
 date as stored in the legal section of the Exoscale Portal of the Client.
 [Previous version](https://github.com/exoscale/terms/blob/master/dpa-previous.markdown)
 [Compare](https://github.com/exoscale/terms/commits/master)
 
-## 1. Definitions
+WHEREAS
 
-GDPR means Regulation (EU) 2016/679 of the European Parliament and of
-the Council of 27 April 2016 on the protection of natural persons with
-regard to the processing of personal data and on the free movement of
-such data, and repealing Directive 95/46/EC (General Data Protection
-Regulation).
+(A) The Company acts as a Data Controller.
 
-The terms "Personal Data", "Data Subject", "Processing", "Controller",
-"Processor", "Union" and "Member State" as used in this Data Processing
-Addendum have the meanings given in the GDPR.
+(B) The Company wishes to subcontract certain Services, which imply the processing of personal data, to the Data Processor.
 
-Unless otherwise defined in this DPA, all capitalized terms used shall
-have the meanings given to them in the T&C.
+(C) The Parties seek to implement a data processing agreement that complies with the requirements of the current legal framework in relation to data processing and with the Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation).
 
-## 2. Details of Processing
+(D) The Parties wish to lay down their rights and obligations.
 
-Subject matter: the subject matter of the data processing under this DPA
-is Client Data.
+IT IS AGREED AS FOLLOWS:
 
-Duration: throughout the Term of the Services being provided by Exoscale
-to Client. Term of Services under this DPA is determined by the Client
-or exceptionally by Exoscale via provisions of the T&C.
+1. Definitions and Interpretation
 
-Nature and Purpose of the Processing: compute, storage, and platform
-services as described in the Website and initiated by Client excluding
-third party services available from the Exoscale Marketplace. The
-purpose is the provision of the Services initiated by Client.
+1.1 Unless otherwise defined herein, capitalized terms and expressions used in this Agreement shall have the following meaning:
 
-Type of personal data: personal data uploaded to the Services under
-Client's Exoscale accounts.
+1.1.1 “Agreement” means this Data Processing Agreement and all Schedules;
 
-Categories of data subjects: the data subjects include without
-limitation: Client's customers, employees, suppliers, and end-users.
+1.1.2 “Company Personal Data” means any Personal Data Processed by a Contracted Processor on behalf of Company pursuant to or in connection with the Principal Agreement;
 
-## 3. Obligations and Rights of the Controller
+1.1.3 “Contracted Processor” means a Subprocessor;
 
-If European Data Protection Legislation applies to the processing of
-Client's data, the parties acknowledge and agree that Exoscale is a
-Processor of Client's data under European Data Protection Legislation,
-that Client is a Controller under European Data Protection Legislation
-(unless when Client acts as a Processor, in which case Exoscale is a
-sub-Processor) and that the parties complies with their obligations
-under applicable European Data Protection Legislation with respect to
-the processing of Personal Data.
+1.1.4 “Data Protection Laws” means EU Data Protection Laws and, to the extent applicable, the data protection or privacy laws of any other country;
 
-## 4. Client Instructions
+1.1.5 “EEA” means the European Economic Area;
 
-By entering into this DPA, the parties agree that the DPA constitutes
-Client's documented instructions regarding Exoscale's processing of
-Personal Data. Exoscale only processes Client Data to the extent that is
-necessary to provide the Services.
+1.1.6 “EU Data Protection Laws” means EU Directive 95/46/EC, as transposed into domestic legislation of each Member State and as amended, replaced or superseded from time to time, including by the GDPR and laws implementing or supplementing the GDPR;
 
-The Processor may suspend the implementation of the instruction until
-it has been confirmed or changed by the client in writing.
+1.1.7 “GDPR” means EU General Data Protection Regulation 2016/679;
 
-The Processor shall immediately inform the controller if, in its opinion, an
-instruction infringes applicable data protection regulations or other Union
-or Member State data protection provisions. The Processor may suspend the
-implementation of the instruction until it has been confirmed or changed by
-the client in writing. The Processor may refuse to execute instructions that are obviously in
-breach of data protection law at any time.
+1.1.8 “Data Transfer” means:
 
-## 5. Confidentiality
+1.1.8.1 a transfer of Company Personal Data from the Company to a Contracted Processor; or
 
-Exoscale does not access, use, or share Client Data to any third party,
-except when this access, use or sharing is necessary to provide the
-Services, or as required to comply with law enforcement requests.
+1.1.8.2 an onward transfer of Company Personal Data from a Contracted Processor to a Subcontracted Processor, or between two establishments of a Contracted Processor, in each case, where such transfer would be prohibited by Data Protection Laws (or by the terms of data transfer agreements put in place to address the data transfer restrictions of Data Protection Laws);
 
-Exoscale ensures that the persons authorized to process personal data
-have committed themselves to confidentiality or are under an appropriate
-statutory obligation of confidentiality.
+1.1.9 “Services” means the services the Company provides as described in the Website by Client excluding third party services available from the Exoscale Marketplace. The purpose is the provision of the Services initiated by Client..
 
-## 6. Security of Processing
+1.1.10 “Subprocessor” means any person appointed by or on behalf of Processor to process Personal Data on behalf of the Company in connection with the Agreement.
 
-Exoscale implements and maintains appropriate technical and
-organizational security measures to protect Client Data against
-accidental destruction, alteration or access. These measures take into
-account the state of the art and include (a) the pseudonymisation and
-encryption of Client Data; (b) the ability to ensure the ongoing
-confidentiality, integrity, availability and resilience of processing
-systems and services; (c) the ability to restore the availability and
-access to personal data in a timely manner in the event of a physical or
-technical incident; (d) a process for regularly testing, assessing and
-evaluating the effectiveness of technical and organizational measures
-for ensuring the security of the processing. Exoscale may assess and
-improve security measures at regular intervals, provided that these
-improvements lead to an increased level of security for providing the
-Services. Exoscale assists the Client in ensuring compliance with the
-obligations pursuant to Articles 32 to 36 of the GDPR given the nature
-of processing and the information available to Exoscale.
+1.2 The terms, “Commission”, “Controller”, “Data Subject”, “Member State”, “Personal Data”, “Personal Data Breach”, “Processing” and “Supervisory Authority” shall have the same meaning as in the GDPR, and their cognate terms shall be construed accordingly.
 
-## 7. Processors
+2. Processing of Company Personal Data
 
-Exoscale maintains a list of its sub-Processors per Service at
-[https://www.exoscale.com/privacy/#data-processors](https://www.exoscale.com/privacy/#data-processors).
-Exoscale informs the Client of any intended changes concerning the
-addition or replacement of other Processors at least 30 days in advance.
-Exoscale makes sure Data Processing Addendums are in place with its
-sub-Processors to ensure compliance with the GDPR and our security/data
-protection policies. If the Client objects the addition or replacement
-of a sub-Processor, they may terminate the services as described in the T&C.
+2.1 Processor shall:
 
-## 8. Data Subject Rights
+2.1.1 comply with all applicable Data Protection Laws in the Processing of Company Personal Data; and
 
-Exoscale assists the Client for the fulfilment of their obligation to
-respond to requests for exercising the data subject's rights as laid
-down in Chapter III of the GDPR: (a) right of access by the data
-subject, (b) right to rectification, (c) right to erasure, (d) right to
-restriction of processing, and (e) right to data portability. Upon
-receiving such requests from data subjects, Exoscale uses commercially
-reasonable efforts to forward requests to the Client.
+2.1.2 not Process Company Personal Data other than on the relevant Company’s documented instructions.
 
-## 9. Deletion and Return
+2.2 The Company instructs Processor to process Company Personal Data.
 
-Client's right to data return is described in Section 13 of the T&C.
-In addition, Exoscale deletes all the personal data after
-the end of the provision of Services and deletes existing copies unless
-Union or Member State law requires storage of the personal data.
+3. Processor Personnel
+Processor shall take reasonable steps to ensure the reliability of any employee, agent or contractor of any Contracted Processor who may have access to the Company Personal Data, ensuring in each case that access is strictly limited to those individuals who need to know / access the relevant Company Personal Data, as strictly necessary for the purposes of the Principal Agreement, and to comply with Applicable Laws in the context of that individual’s duties to the Contracted Processor, ensuring that all such individuals are subject to confidentiality undertakings or professional or statutory obligations of confidentiality.
 
-## 10. Audit rights
+4. Security
 
-Exoscale allows for and contributes to audits, including inspections, to
-demonstrate compliance with the obligations and measures described in
-this DPA conducted by the Client or another auditor mandated by the
-Client by means of random checks during business hours, which are
-ordinarily to be announced 1 month in prior. In order to carry out an
-inspection, the Client shall send a detailed audit / control plan to
-Exoscale at least two weeks before the scheduled date of the audit,
-indicating the scope, duration of the audit and the start date of the
-audit. Exoscale shall review the audit/control plan and provide the
-Client with any material concerns and questions, such as information
-requests, that may affect the security, privacy or employment policy of
-the Exoscale. In any case, Exoscale cooperates cooperatively with the
-Client to agree on a final audit/control plan. Exoscale may claim
-remuneration for enabling Client inspections. Proof of the
-implementation of technical and organizational measures to comply with
-the obligations arising from this contract may be provided by:
+4.1 Taking into account the state of the art, the costs of implementation and the nature, scope, context and purposes of Processing as well as the risk of varying likelihood and severity for the rights and freedoms of natural persons, Processor shall in relation to the Company Personal Data implement appropriate technical and organizational measures to ensure a level of security appropriate to that risk, including, as appropriate, the measures referred to in Article 32(1) of the GDPR.
 
-a) Certification according to an approved certification procedure in
-accordance with Art.42 GDPR;
-b) Current auditor's certificates, reports or excerpts from reports
-provided by independent bodies (e.g. auditor, Data Protection
-Officer, IT security department, data privacy auditor, quality
-auditor)
-c) A relevant certification by IT security or data protection auditing
-(e.g. according to IT Baseline Protection certification developed by
-the [German](https://en.wikipedia.org/wiki/Germany) Federal Office
-for Security in Information Technology (BSI)) or ISO/IEC).
-d) Annual reports by Exoscale
+4.2 In assessing the appropriate level of security, Processor shall take account in particular of the risks that are presented by Processing, in particular from a Personal Data Breach.
 
-## Schedule 1: Exoscale Security Controls
+5. Subprocessing
 
-### Confidentiality
+5.1 Processor shall not appoint (or disclose any Company Personal Data to) any Subprocessor unless required or authorized by the Company.
+5.2 Processor maintains a list of its sub-Processors per Service at https://www.exoscale.com/privacy/#data-processors. Processor informs the Company of any intended changes concerning the addition or replacement of other Processors at least 30 days in advance. Processor makes sure Data Processing Addendums are in place with its sub-Processors to ensure compliance with the GDPR and our security/data protection policies. If the Company objects the addition or replacement of a sub-Processor, they may terminate the services as described in the T&C.
 
-**Physical Access Control**: physical access to facilities is guarded by
-24/7 staff performing identity controls, as well as automated mechanisms
-including fenced doors with biometric checks, CCTV recording, and motion
-detection.
+6. Data Subject Rights
 
-**Electronic access control**: strong password policy, encryption of
-at-rest data, use of state-of-the art software security mechanisms.
+6.1 Taking into account the nature of the Processing, Processor shall assist the Company by implementing appropriate technical and organisational measures, insofar as this is possible, for the fulfilment of the Company obligations, as reasonably understood by Company, to respond to requests to exercise Data Subject rights under the Data Protection Laws.
 
-**Internal Access Control**: data access requests to Exoscale systems
-are made according to an authorizations scheme implementing need-based
-rights of access. All system access events are logged within Exoscale's
-visibility platform.
+6.2 Processor shall:
 
-**Isolation Control**: strong logical separation is enforced between
-Data Subjects.
+6.2.1 promptly notify Company if it receives a request from a Data Subject under any Data Protection Law in respect of Company Personal Data; and
 
-**Pseudonymization**: Personal data is processed in a way allowing that
-the data cannot be associated with a specific Data Subject without the
-assistance of additional information, stored separately.
+6.2.2 ensure that it does not respond to that request except on the documented instructions of Company or as required by Applicable Laws to which the Processor is subject, in which case Processor shall to the extent permitted by Applicable Laws inform Company of that legal requirement before the Contracted Processor responds to the request.
 
-### Integrity
+7. Personal Data Breach
 
-**Data Transfer Control**: Personal Data is only transferred in an
-encrypted way to ensure no unauthorized reading, copying, changes or
-deletion happens during the transfer.
+7.1 Processor shall notify Company without undue delay upon Processor becoming aware of a Personal Data Breach affecting Company Personal Data, providing Company with sufficient information to allow the Company to meet any obligations to report or inform Data Subjects of the Personal Data Breach under the Data Protection Laws.
 
-**Data Entry Control**: data entry events are logged within Exoscale's
-visibility platform.
+7.2 Processor shall co-operate with the Company and take reasonable commercial steps as are directed by Company to assist in the investigation, mitigation and remediation of each such Personal Data Breach.
 
-### Availability and Resilience
+8. Data Protection Impact Assessment and Prior Consultation Processor shall provide reasonable assistance to the Company with any data protection impact assessments, and prior consultations with Supervising Authorities or other competent data privacy authorities, which Company reasonably considers to be required by article 35 or 36 of the GDPR or equivalent provisions of any other Data Protection Law, in each case solely in relation to Processing of Company Personal Data by, and taking into account the nature of the Processing and information available to, the Contracted Processors.
 
-**Availability control**:
+9. Deletion or return of Company Personal Data
 
-- Physical: redundant power, network and storage mitigate against
-  hardware issues leading to data unavailability or loss.
-- Logical: firewalling provides strong systems isolation. Online and
-  offline backups are made to prevent accidental or wilful destruction
-  or loss.
+9.1 Subject to this section 9 Processor shall promptly and in any event within 10 business days of the date of cessation of any Services involving the Processing of Company Personal Data (the “Cessation Date”), delete and procure the deletion of all copies of those Company Personal Data.
 
-**Rapid recovery**: in the event of a physical or technical incident,
-Exoscale keeps the ability to restore the availability and access to
-personal data in a timely manner.
+10. Audit rights
 
-### Procedures for regular testing, assessment and evaluation
+10.1 Subject to this section 10, Processor shall make available to the Company on request all information necessary to demonstrate compliance with this Agreement, and shall allow for and contribute to audits, including inspections, by the Company or an auditor mandated by the Company in relation to the Processing of the Company Personal Data by the Contracted Processors.
 
-**Data Protection Management**: Exoscale reviews on a yearly basis 1)
-its record of activity that inventories the processing of personal data,
-and 2) its Data Access response procedures.
+10.2 Information and audit rights of the Company only arise under section 10.1 to the extent that the Agreement does not otherwise give them information and audit rights meeting the relevant requirements of Data Protection Law.
 
-**Incident Response Management**: Exoscale carries yearly assessments of
-incident response scenarios, including data breach and data recovery
-procedures.
+11. Data Transfer
 
-**Data Protection by Design and by Default**: Exoscale processes data
-while ensuring the processing is done with the highest level of privacy
-protection:
+11.1 The Processor may not transfer or authorize the transfer of Data to countries outside the EU and/or the European Economic Area (EEA) without the prior written consent of the Company. If personal data processed under this Agreement is transferred from a country within the European Economic Area to a country outside the European Economic Area, the Parties shall ensure that the personal data are adequately protected. To achieve this, the Parties shall, unless agreed otherwise, rely on EU approved standard contractual clauses for the transfer of personal data.
 
-- Only a minimal set of data is processed, stored, or transferred over
-  the wire.
-- Storage period is the shortest possible for the given data
-  processed.
-- Access is as restricted as possible.
-- Encryption is used for all data access workloads.
-- Pseudonymization is generalized in the processing of Personal Data.
+12. General Terms
 
-**Order or Contact Control**: data processors are subject to clear and
-unambiguous contractual arrangements, formalized order management,
-strict controls on the selection of the Service Provider, as well as
-regular supervisory follow-up checks.
+12.1 Confidentiality. Each Party must keep this Agreement and information it receives about the other Party and its business in connection with this Agreement (“Confidential Information”) confidential and must not use or disclose that Confidential Information without the prior written consent of the other Party except to the extent that:
+(a) disclosure is required by law;
+(b) the relevant information is already in the public domain.
+
+12.2 Notices. All notices and communications given under this Agreement must be in writing and will be delivered personally, sent by post or sent by email to the address or email address set out in the heading of this Agreement at such other address as notified from time to time by the Parties changing address.
+
+13. Governing Law and Jurisdiction
+
+13.1 This Agreement is governed by the laws of Switzerland.
+
+13.2 Any dispute arising in connection with this Agreement, which the Parties will not be able to resolve amicably, will be submitted to the exclusive jurisdiction of the courts of _________________, subject to possible appeal to __________________________________.
+
+

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -21,7 +21,7 @@ The terms of this Agreement shall follow the terms of the Principal
 Agreements. Terms not defined herein shall have the meaning as set forth
 in the Principal Agreements.
 
-This Agreement is applicable starting March 15th, 2025, and binding at
+This Agreement is applicable starting May 5th, 2025, and binding at
 Company's acceptance date, as stored in the legal section of Company's
 account at Exoscale.
 

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -1,147 +1,341 @@
-This Data Processing Addendum, hereafter "DPA", is an Agreement between
-Akenes SA hereafter "Exoscale" (referred to as the "**Processor**") and the client
-hereafter "Client" (referred to as the "**Company**").
-This Addendum is either an extension to the Exoscale Terms and Conditions
-available at <https://www.exoscale.com/terms/>, or the EUSA, as the case
-maybe, (each hereafter T&C) as updated from time to time between Client
-and Exoscale, when GDPR applies to your use of the Services to process
-Client Data.
+This Data Processing Addendum (referred to as the "Agreement") forms
+part of the Contract for Services under Exoscale's [Terms and
+Conditions](https://www.exoscale.com/terms/) and/or Exoscale's [End User
+Service Agreement](https://www.exoscale.com/eusa/) (both referred to as
+the "Principal Agreements") between Akenes SA (referred to as the
+"**Processor**") and the "**Company**" using Exoscale's services.
 
-Applicable starting Decemeber 1st, 2024 and binding at Client acceptance
-date as stored in the legal section of the Exoscale Portal of the Client.
-[Previous version](https://github.com/exoscale/terms/blob/master/dpa-previous.markdown)
-[Compare](https://github.com/exoscale/terms/commits/master)
+Exoscale is a registered trademark of the Processor Akenes SA, Boulevard
+de Grancy 19A, 1006 Lausanne, Switzerland, company identification number
+CHE-423.524.322.
 
-WHEREAS
+This Agreement governs the specific requirements of Data Protection Laws
+to the extent that Company's use of Exoscale's Services implies the
+processing of Personal Data subject to Data Protection Laws.
 
-(A) The Company acts as a Data Controller.
+This Agreement is complementary to our [Privacy
+Policy](https://www.exoscale.com/privacy/), which serves as the primary
+reference for our data protection practices and measures.
 
-(B) The Company wishes to subcontract certain Services, which imply the processing of personal data, to the Data Processor.
+The terms of this Agreement shall follow the terms of the Principal
+Agreements. Terms not defined herein shall have the meaning as set forth
+in the Principal Agreements.
 
-(C) The Parties seek to implement a data processing agreement that complies with the requirements of the current legal framework in relation to data processing and with the Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation) and the Federal Act on Data Protection of 25 September 2020.
-(D) The Parties wish to lay down their rights and obligations.
+This Agreement is applicable starting March 15th, 2025, and binding at
+Company's acceptance date, as stored in the legal section of Company's
+account at Exoscale.
 
-IT IS AGREED AS FOLLOWS:
+**WHEREAS**
+<style>
+    ol {list-style-type: lower-alpha;}
+    li {margin-bottom: 1em;}
+</style>
+
+1. The Company acts as a Data Controller (the "Controller").
+
+2. The Company wishes to subcontract certain Services (as defined
+   below), which imply the processing of Personal Data, to Exoscale,
+   acting as a Data Processor (the "Processor").
+
+3. The Parties seek to implement a data processing agreement that
+   complies with the requirements of the current legal framework in
+   relation to data processing and with the Regulation (EU) 2016/679 of
+   the European Parliament and of the Council of 27 April 2016 on the
+   protection of natural persons with regard to the processing of
+   Personal Data and on the free movement of such data, and repealing
+   Directive 95/46/EC (General Data Protection Regulation) and the
+   Swiss Federal Act on Data Protection of 25 September 2020 (FADP; RS
+   235.1) and other applicable data protection laws.
+
+4. The Parties wish to lay down their rights and obligations.
+
+**IT IS AGREED AS FOLLOWS:**
 
 ## 1. Definitions and Interpretation
 
-1.1 Unless otherwise defined herein, capitalized terms and expressions used in this Agreement shall have the following meaning:
+Unless otherwise defined herein, capitalized terms and expressions used
+in this Agreement shall have the following meaning:
 
-1.1.1 “Agreement” means this Data Processing Agreement and all Schedules;
+1. "**Agreement**" means this Data Processing Addendum and all Schedules;
 
-1.1.2 “Company Personal Data” means any Personal Data Processed by a Contracted Processor on behalf of Company pursuant to or in connection with the Principal Agreement;
+2. "**Company Personal Data**" means any Personal Data related to the
+   Company or Company's customers or employees processed in connection
+   with the Principal Agreements;
 
-1.1.3 “Contracted Processor” means a Subprocessor;
+3. "**Contracted Processor**" means a Subprocessor;
 
-1.1.4 “Data Protection Laws” means EU Data Protection Laws and, to the extent applicable, the data protection or privacy laws of any other country;
+4. "**Data Protection Laws**" means EU Data Protection Laws and, to the
+   extent applicable, the data protection or privacy laws of any other
+   country;
 
-1.1.5 “EEA” means the European Economic Area;
+5. "**EEA**" means the European Economic Area;
 
-1.1.6 “EU Data Protection Laws” means EU Directive 95/46/EC, as transposed into domestic legislation of each Member State and as amended, replaced or superseded from time to time, including by the GDPR and laws implementing or supplementing the GDPR;
+6. "**EU Data Protection Laws**" means EU Directive 95/46/EC, as transposed
+   into domestic legislation of each Member State, and as amended,
+   replaced, or superseded from time to time, including by the GDPR and
+   laws implementing or supplementing the GDPR;
 
-1.1.7 “GDPR” means EU General Data Protection Regulation 2016/679;
+7. "**GDPR**" means EU General Data Protection Regulation 2016/679;
 
-1.1.8 “FADP” means Federal Act on Data Protection of 25 September 2020 (FADP ; RS 235.1)
+8. "**FADP**" means Federal Act on Data Protection of the 25th of September
+   2020 (FADP; RS 235.1)
 
-1.1.9 “Data Transfer” means:
+9. "**Data Transfer**" means a transfer of Company Personal Data from
+   Controller to the Processor or a Contracted Processor; or an onward
+   transfer of Company Personal Data from the Processor to a Contracted
+   Processor, or between two establishments of Processor or Contracted
+   Processor;
 
-1.1.9.1 a transfer of Company Personal Data from the Company to a Contracted Processor; or
+10. "**Services**" means online services provided by the Processor, as
+    described at Exoscale's Website, consumed by Company excluding third
+    Party services available from the Exoscale's Marketplace. The
+    purpose is the provision of the Services initiated by Company;
 
-1.1.9.2 an onward transfer of Company Personal Data from a Contracted Processor to a Subcontracted Processor, or between two establishments of a Contracted Processor, in each case, where such transfer would be prohibited by Data Protection Laws (or by the terms of data transfer agreements put in place to address the data transfer restrictions of Data Protection Laws);
+11. "**Subprocessor**" means any person appointed by or on behalf of
+    Processor to process Personal Data on behalf of Controller in
+    connection with the Agreement.
 
-1.1.10 “Services” means the services the Company provides as described in the Website by Client excluding third party services available from the Exoscale Marketplace. The purpose is the provision of the Services initiated by Client.
-
-1.1.11 “Subprocessor” means any person appointed by or on behalf of Processor to process Personal Data on behalf of the Company in connection with the Agreement.
-
-1.2 The terms, “Commission”, “Controller”, “Data Subject”, “Member State”, “Personal Data”, “Personal Data Breach”, “Processing” and “Supervisory Authority” shall have the same meaning as in the GDPR, and their cognate terms shall be construed accordingly.
+The terms "Commission", "Controller", "Data Subject", "Member State",
+"Personal Data", "Personal Data Breach", "Processing", "Processor", and
+"Supervisory Authority" shall have the same meaning as in the GDPR or
+other applicable Data Protection Law, and their cognate terms shall be
+construed accordingly.
 
 ## 2. Processing of Company Personal Data
 
 2.1 Processor shall:
 
-2.1.1 comply with all applicable Data Protection Laws in the Processing of Company Personal Data; and
+1. comply with all applicable Data Protection Laws in the Processing of
+   Company Personal Data;
 
-2.1.2 not Process Company Personal Data other than on the relevant Company’s documented instructions.
+2. not process Company Personal Data other than on Controller's
+   documented instructions.
 
-2.2 The Company instructs Processor to process Company Personal Data.
+2.2 Controller instructs Processor to process Company Personal Data to:
+
+1. provide the Services and related technical support;
+
+2. fulfil legal obligations or resolve disputes;
+
+3. exercise any internal task aimed to optimize the security, privacy,
+   confidentiality, and functionalities of the Services;
+
+4. exercise internal reporting, financial reporting, and other similar
+   internal tasks.
 
 ## 3. Processor Personnel
-Processor shall take reasonable steps to ensure the reliability of any employee, agent or contractor of any Contracted Processor who may have access to the Company Personal Data, ensuring in each case that access is strictly limited to those individuals who need to know / access the relevant Company Personal Data, as strictly necessary for the purposes of the Principal Agreement, and to comply with Applicable Laws in the context of that individual’s duties to the Contracted Processor, ensuring that all such individuals are subject to confidentiality undertakings or professional or statutory obligations of confidentiality.
+
+Processor shall take reasonable steps to ensure the reliability of any
+employee, agent or contractor of any Contracted Processor who may have
+access to Company Personal Data, ensuring in each case that access is
+strictly limited to those individuals who need to know/access the
+relevant Company Personal Data, as strictly necessary for the purposes
+of the Principal Agreements, and/or to comply with Data Protection Laws
+and other relevant legislation, ensuring that all such individuals are
+subject to confidentiality undertakings or professional or statutory
+obligations of confidentiality.
 
 ## 4. Security
 
-4.1 Taking into account the state of the art, the costs of implementation and the nature, scope, context and purposes of Processing as well as the risk of varying likelihood and severity for the rights and freedoms of natural persons, Processor shall in relation to the Company Personal Data implement appropriate technical and organizational measures to ensure a level of security appropriate to that risk, including, as appropriate, the measures referred to in Article 32(1) of the GDPR.
+4.1 In accordance with Article 32 (1) of the GDPR, the Processor shall
+implement technical and organizational measures to ensure a level of
+security appropriate to the risk, considering the state of the art, the
+costs of implementation, and the nature, scope, context, and purposes of
+Processing, to protect the rights and freedoms of natural persons, and
+minimize the risk of a Personal Data Breach.
 
-4.2 In assessing the appropriate level of security, Processor shall take account in particular of the risks that are presented by Processing, in particular from a Personal Data Breach.
+These measures include:
 
-4.3 These measures take into account the state of the art and include:
-- (a) the pseudonymisation and encryption of Client Data;
-- (b) the ability to ensure the ongoing confidentiality, integrity, availability and resilience of processing systems and services;
-- (c) the ability to restore the availability and access to personal data in a timely manner in the event of a physical or technical incident;
-- (d) a process for regularly testing, assessing and evaluating the effectiveness of technical and organizational measures for ensuring the security of the processing.
+1. the pseudonymization and encryption of Company Data;
+
+2. the ability to ensure the ongoing confidentiality, integrity,
+   availability, and resilience of Processing Services;
+
+3. the ability to restore the availability and access to Company
+   Personal Data in a timely manner in the event of a physical or
+   technical incident;
+
+4. a process for regularly testing, assessing, and evaluating the
+   effectiveness of technical and organizational measures for ensuring
+   the security of the Processing.
+
+4.2 The Processor continues to adjust technical and organizational
+measures to follow latest versions of security frameworks and comply
+with most recent revisions of internationally recognized security and
+privacy certifications as found at ﷟HYPERLINK
+<https://www.exoscale.com/compliance>. These certifications are to
+demonstrate compliance with the requirements set out in section 4.1 of
+this Agreement, as proposed in Article 32 (3) GDPR.
 
 ## 5. Subprocessing
 
-5.1 Processor shall not appoint (or disclose any Company Personal Data to) any Subprocessor unless required or authorized by the Company.
+5.1 Processor shall not appoint (or disclose any Company Personal Data
+to) any Subprocessor unless authorized by the Company. The Company
+acknowledges and approves the following list of Subprocessors:
 
-5.2 Processor maintains a list of its sub-Processors per Service at https://www.exoscale.com/privacy/#data-processors. Processor informs the Company of any intended changes concerning the addition or replacement of other Processors at least 30 days in advance. Processor makes sure Data Processing Addendums are in place with its sub-Processors to ensure compliance with the GDPR and our security/data protection policies. If the Company objects the addition or replacement of a sub-Processor, they may terminate the services as described in the T&C.
+| Name of Contracted Processor | Purpose                                                                                                              | Location          |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------|
+| Aiven Oy                     | Orchestration of Database as a Service (DbaaS) instances running on Processor's infrastructure as Exoscale Services. | Helsinki, Finland |
+
+Company understands that this list may be updated by Processor
+regularly. Processor informs Company of any intended changes concerning
+the addition or replacement of other Processors at least 30 (thirty)
+days in advance. If Company objects the addition or replacement of a
+Subprocessor, it may terminate the Services upon 30 (thirty) days
+notice.
+
+5.2 Processor ensures that Subprocessors are subject to an agreement
+with Processor no less restrictive and protective than the present
+Agreement with respect to the protection of Company Personal Data to the
+extent applicable to the nature of the Services provided by the
+Subprocessor.
 
 ## 6. Data Subject Rights
 
-6.1 Taking into account the nature of the Processing, Processor shall assist the Company by implementing appropriate technical and organisational measures, insofar as this is possible, for the fulfilment of the Company obligations, as reasonably understood by Company, to respond to requests to exercise Data Subject rights under the Data Protection Laws.
+Considering the nature of the Processing, Processor shall assist Company
+for the fulfilment of Company's obligations to respond to requests to
+exercise Data Subject rights under applicable Data Protection Laws.
 
-6.2 Processor shall:
+**Processor shall:**
 
-6.2.1 promptly notify Company if it receives a request from a Data Subject under any Data Protection Law in respect of Company Personal Data; and
+1. promptly notify Company if it receives a request from a Data Subject
+   under any Data Protection Law in respect of Company Personal Data;
+   and
 
-6.2.2 ensure that it does not respond to that request except on the documented instructions of Company or as required by Applicable Laws to which the Processor is subject, in which case Processor shall to the extent permitted by Applicable Laws inform Company of that legal requirement before the Contracted Processor responds to the request.
+2. ensure that it does not respond to that request except on the
+   documented instructions of Controller or as required by applicable
+   laws to which the Processor is subject, in which case Processor
+   shall to the extent permitted by applicable laws inform Controller
+   of that legal requirement before the Contracted Processor responds
+   to the request.
 
 ## 7. Personal Data Breach
 
-7.1 Processor shall notify Company without undue delay upon Processor becoming aware of a Personal Data Breach affecting Company Personal Data, providing Company with sufficient information to allow the Company to meet any obligations to report or inform Data Subjects of the Personal Data Breach under the Data Protection Laws.
+7.1 The Processor shall manage any Personal Data Breach in compliance
+with applicable Data Protection Laws and its internal Personal Data
+Breach procedures. In the event of a Personal Data Breach affecting
+Company Personal Data, the Processor shall notify the Company without
+delay, providing sufficient information to enable the Company to fulfill
+its obligations under Data Protection Laws, including informing Data
+Subjects, as necessary. In such cases, the Processor shall provide the
+Company with sufficient information to allow the Company to meet any
+obligations to report or inform Data Subjects of the Personal Data
+Breach under the Data Protection Laws.
 
-7.2 Processor shall co-operate with the Company and take reasonable commercial steps as are directed by Company to assist in the investigation, mitigation and remediation of each such Personal Data Breach.
+7.2 Processor shall co-operate with the Company and take reasonable
+commercial steps as directed by the Company to assist in the
+investigation, mitigation, and remediation of each such Personal Data
+Breach.
 
-## 8. Data Protection Impact Assessement
+## 8. Data Protection Impact Assessment and Prior Consultation
 
-Data Protection Impact Assessment and Prior Consultation Processor shall provide reasonable assistance to the Company with any data protection impact assessments, and prior consultations with Supervising Authorities or other competent data privacy authorities, which Company reasonably considers to be required by article 35 or 36 of the GDPR or equivalent provisions of any other Data Protection Law, in each case solely in relation to Processing of Company Personal Data by, and taking into account the nature of the Processing and information available to, the Contracted Processors.
+Processor shall provide reasonable assistance to Company with any data
+protection impact assessments, and prior consultations with Supervising
+Authorities or other competent data privacy authorities, which Company
+reasonably considers to be required by article 35 or 36 of the GDPR or
+equivalent provisions of any other Data Protection Law, in each case
+solely in relation to Processing of Company Personal Data, and taking
+into account the nature of the Processing and information available to
+the Contracted Processors.
 
-## 9. Deletion or return of Company Personal Data
+## 9. Deletion or Return of Company Personal Data
 
-9.1 Subject to this section 9 Processor shall promptly and in any event within 10 business days of the date of cessation of any Services involving the Processing of Company Personal Data (the “Cessation Date”), delete and procure the deletion of all copies of those Company Personal Data.
+9.1 In case of cessation of any Service involving the Processing of
+Company Personal Data, the Processor shall delete all Company Personal
+Data. Should the Company require a copy of their data, they must request
+it before the deletion of their account; requests made after the account
+has been deleted can no longer be considered.
 
-9.2 Client’s right to data return is described in Section 13 of the T&C. In addition, Processor deletes all the personal data after the end of the provision of Services and deletes existing copies unless Union or Member State law requires storage of the personal data.
+9.2 Upon request of Company, notified at least 30 (thirty) days prior to
+termination of the Services, Processor shall make Company Data available
+to Company in its original format through the Processor's recovery
+service, upon charge of a recovery service fee.
 
-## 10. Liability
+9.3 Unless a request for the Processor's recovery service is made,
+Processor shall have no obligation to maintain or provide any of Company
+Data after termination of the Services and shall thereafter, unless
+legally prohibited, promptly and in any event within 10 (ten) business
+days of the date of cessation of any Services involving the Processing
+of Company Personal Data (the "Cessation Date"), delete and procure the
+deletion of all copies of those Company Personal Data.
 
-The Processor shall indemnify Company (and each of their respective officers, employees and agents) against all losses (including any claim, damage, cost, charge, fine, fees, levies, award, expense or other liability of any nature, whether direct, indirect, or consequential) arising out of or in connection with any failure by the Processor (and by any Subprocessor) to comply with the provisions of this Agreement or any Applicable Law.
+## 10. Audit Rights
 
-## 11. Audit rights
+10.1 Subject to this section 10, Processor shall make available to
+Company on request all information necessary to demonstrate compliance
+with this Agreement, and shall allow for and contribute to audits,
+including inspections, by Company or an auditor mandated by Company in
+relation to the Processing of the Company Personal Data by the
+Contracted Processors. Company shall not exercise its audit rights more
+than once per calendar year except following a Personal Data Breach or
+an instruction by a regulatory authority. Company shall give Processor
+at least 60 (sixty) days prior written notice of its intention to audit
+Processor pursuant to this Agreement.
 
-11.1 Subject to this section 11, Processor shall make available to the Company on request all information necessary to demonstrate compliance with this Agreement, and shall allow for and contribute to audits, including inspections, by the Company or an auditor mandated by the Company in relation to the Processing of the Company Personal Data by the Contracted Processors.
+10.2 Audit shall be conducted during Processor's business hours, shall
+not disrupt Processor's operations, and shall ensure the protection of
+the Company's, Processor's, and other Data Subjects' Personal Data.
+Processor and Company shall mutually agree in advance on the date,
+scope, duration, and security and confidentiality controls applicable to
+the audit. Company acknowledges that signing a non-disclosure agreement
+may be required by the Controller prior to the audit.
 
-11.2 Information and audit rights of the Company only arise under section 11.1 to the extent that the Agreement does not otherwise give them information and audit rights meeting the relevant requirements of Data Protection Law.
+10.3 Information and audit rights of Company only arise under section 10
+to the extent that the Agreement does not otherwise give them
+information and audit rights meeting the relevant requirements of Data
+Protection Law.
 
-11.3 Processor allows for and contributes to audits, including inspections, to demonstrate compliance with the obligations and measures described in this DPA conducted by the Client or another auditor mandated by the Client by means of random checks during business hours, which are ordinarily to be announced 1 month in prior. In order to carry out an inspection, the Client shall send a detailed audit / control plan to Exoscale at least two weeks before the scheduled date of the audit, indicating the scope, duration of the audit and the start date of the audit. Exoscale shall review the audit/control plan and provide the Client with any material concerns and questions, such as information requests, that may affect the security, privacy or employment policy of the Exoscale. In any case, Exoscale cooperates cooperatively with the Client to agree on a final audit/control plan. Exoscale may claim remuneration for enabling Client inspections. Proof of the implementation of technical and organizational measures to comply with the obligations arising from this contract may be provided by:
-- a) Certification according to an approved certification procedure in accordance with Art.42 GDPR;
-- b) Current auditor’s certificates, reports or excerpts from reports provided by independent bodies (e.g. auditor, Data Protection Officer, IT security department, data privacy auditor, quality auditor)
-- c) A relevant certification by IT security or data protection auditing (e.g. according to IT Baseline Protection certification developed by the [German](https://en.wikipedia.org/wiki/Germany) Federal Office for Security in Information Technology (BSI)) or ISO/IEC).
-- d) Annual reports by Exoscale.
+## 11. Data Transfer
 
-## 12. Data Transfer
+11.1 Processor shall not transfer any Company Data, including Company
+Personal Data, between countries unless authorized by Company.
 
-12.1 The Processor may not transfer or authorize the transfer of Data to countries outside the EU and/or the European Economic Area (EEA) without the prior written consent of the Company. If personal data processed under this Agreement is transferred from a country within the European Economic Area to a country outside the European Economic Area, the Parties shall ensure that the personal data are adequately protected. To achieve this, the Parties shall, unless agreed otherwise, rely on EU approved standard contractual clauses for the transfer of personal data. To the extent possible, the Processor shall only transfer or authorize the transfer of Data to countries within Switzerland, the EU and/or countries subject to an adequacy decision, as provided for in art. 45 GDPR and art. 16 Swiss FADP.
+11.2 Processor shall only transfer or authorize the transfer of Data
+within Switzerland, the EU, the EEA, and/or countries subject to an
+adequacy decision, as provided for in art. 45 GDPR and art. 16 Swiss
+FADP. If Personal Data processed under this Agreement is transferred
+from Switzerland or any country within the EU, the EEA, or any country
+subject to an adequacy decision to a country outside of this scope, the
+Parties shall ensure that the Personal Data is adequately protected. To
+achieve this, the Parties shall, unless agreed otherwise, rely on
+Switzerland- and/or EU- and/or EEA-approved and then-current standard
+contractual clauses for the transfer of Personal Data or other transfer
+mechanisms as provided by Data Protection Laws. Processor shall be
+authorized to perform such transfers to Subprocessors provided that
+adequate safeguards are implemented in regard to the nature of the
+transfer.
 
-## 13. General Terms
+## 12. General Terms
 
-13.1 Confidentiality. Each Party must keep this Agreement and information it receives about the other Party and its business in connection with this Agreement (“Confidential Information”) confidential and must not use or disclose that Confidential Information without the prior written consent of the other Party except to the extent that:
-(a) disclosure is required by law;
-(b) the relevant information is already in the public domain.
+**12.1 Compliance with Applicable Laws:** Processor will process Company
+Personal Data in accordance with this Agreement and Data Protection Laws
+applicable to its role under this Agreement. Processor is not
+responsible nor liable for complying with Data Protection Laws solely
+applicable to Company by virtue of its business or industry.
 
-13.2 Notices. All notices and communications given under this Agreement must be in writing and will be delivered personally, sent by email to the address provided during account creation.
+**12.2 Confidentiality:** Each Party must keep any information it
+receives about the other Party and its business in connection with this
+Agreement ("Confidential Information") confidential and must not use or
+disclose that Confidential Information without the prior written consent
+of the other Party except to the extent that:
 
-## 14. Governing Law and Jurisdiction
+1. disclosure is required by law;
 
-14.1 This Agreement is governed by the laws of Switzerland.
+2. the relevant information is already in the public domain through no
+   fault of the Parties.
 
-14.2 Any dispute arising in connection with this Agreement, which the Parties will not be able to resolve amicably, will be submitted to the exclusive jurisdiction of the courts of Lausanne, Switzerland.
+**12.3 Notices:** All notices and communications given under this
+Agreement must be in writing and will be sent by email. Controller shall
+be notified by email sent to the address related to its use of the
+Services under the Principal Agreements. Processor shall be notified by
+email sent to the address: privacy@exoscale.com.
+
+**12.4 Governing Law and Jurisdiction:** This Agreement shall be
+governed by Swiss law, without regard to the choice or conflicts of law
+provisions of any jurisdiction to the contrary, and disputes, actions,
+claims or causes of action arising out of or in connection with this
+Agreement, an order form, any document incorporated by reference,
+Exoscale technology, or the Services shall be subject to the exclusive
+jurisdiction of Switzerland, specifically within the canton of Vaud
+(French: Canton de Vaud). It is governed by Swiss federal laws as well
+as the laws and regulations of the canton of Vaud.

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -114,7 +114,8 @@ Data Protection Impact Assessment and Prior Consultation Processor shall provide
 
 ## 10. Liability
 
-The Processor shall indemnify Controller (and each of their respective officers, employees and agents) against all losses (including any claim, damage, cost, charge, fine, fees, levies, award, expense or other liability of any nature, whether direct, indirect, or consequential) arising out of or in connection with any failure by the Processor (and by any Subprocessor) to comply with the provisions of this Agreement or any Applicable Law.
+The Processor shall indemnify Company (and each of their respective officers, employees and agents) against all losses (including any claim, damage, cost, charge, fine, fees, levies, award, expense or other liability of any nature, whether direct, indirect, or consequential) arising out of or in connection with any failure by the Processor (and by any Subprocessor) to comply with the provisions of this Agreement or any Applicable Law.
+
 ## 11. Audit rights
 
 11.1 Subject to this section 11, Processor shall make available to the Company on request all information necessary to demonstrate compliance with this Agreement, and shall allow for and contribute to audits, including inspections, by the Company or an auditor mandated by the Company in relation to the Processing of the Company Personal Data by the Contracted Processors.

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -102,7 +102,9 @@ Processor shall take reasonable steps to ensure the reliability of any employee,
 
 7.2 Processor shall co-operate with the Company and take reasonable commercial steps as are directed by Company to assist in the investigation, mitigation and remediation of each such Personal Data Breach.
 
-## 8. Data Protection Impact Assessment and Prior Consultation Processor shall provide reasonable assistance to the Company with any data protection impact assessments, and prior consultations with Supervising Authorities or other competent data privacy authorities, which Company reasonably considers to be required by article 35 or 36 of the GDPR or equivalent provisions of any other Data Protection Law, in each case solely in relation to Processing of Company Personal Data by, and taking into account the nature of the Processing and information available to, the Contracted Processors.
+## 8. Data Protection Impact Assessement
+
+Data Protection Impact Assessment and Prior Consultation Processor shall provide reasonable assistance to the Company with any data protection impact assessments, and prior consultations with Supervising Authorities or other competent data privacy authorities, which Company reasonably considers to be required by article 35 or 36 of the GDPR or equivalent provisions of any other Data Protection Law, in each case solely in relation to Processing of Company Personal Data by, and taking into account the nature of the Processing and information available to, the Contracted Processors.
 
 ## 9. Deletion or return of Company Personal Data
 

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -26,18 +26,14 @@ Company's acceptance date, as stored in the legal section of Company's
 account at Exoscale.
 
 **WHEREAS**
-<style>
-    ol {list-style-type: lower-alpha;}
-    li {margin-bottom: 1em;}
-</style>
 
-1. The Company acts as a Data Controller (the "Controller").
+- a) The Company acts as a Data Controller (the "Controller").
 
-2. The Company wishes to subcontract certain Services (as defined
+- b) The Company wishes to subcontract certain Services (as defined
    below), which imply the processing of Personal Data, to Exoscale,
    acting as a Data Processor (the "Processor").
 
-3. The Parties seek to implement a data processing agreement that
+- c) The Parties seek to implement a data processing agreement that
    complies with the requirements of the current legal framework in
    relation to data processing and with the Regulation (EU) 2016/679 of
    the European Parliament and of the Council of 27 April 2016 on the
@@ -47,7 +43,7 @@ account at Exoscale.
    Swiss Federal Act on Data Protection of 25 September 2020 (FADP; RS
    235.1) and other applicable data protection laws.
 
-4. The Parties wish to lay down their rights and obligations.
+- d) The Parties wish to lay down their rights and obligations.
 
 **IT IS AGREED AS FOLLOWS:**
 
@@ -56,42 +52,42 @@ account at Exoscale.
 Unless otherwise defined herein, capitalized terms and expressions used
 in this Agreement shall have the following meaning:
 
-1. "**Agreement**" means this Data Processing Addendum and all Schedules;
+- a) "**Agreement**" means this Data Processing Addendum and all Schedules;
 
-2. "**Company Personal Data**" means any Personal Data related to the
+- b) "**Company Personal Data**" means any Personal Data related to the
    Company or Company's customers or employees processed in connection
    with the Principal Agreements;
 
-3. "**Contracted Processor**" means a Subprocessor;
+- c) "**Contracted Processor**" means a Subprocessor;
 
-4. "**Data Protection Laws**" means EU Data Protection Laws and, to the
+- d) "**Data Protection Laws**" means EU Data Protection Laws and, to the
    extent applicable, the data protection or privacy laws of any other
    country;
 
-5. "**EEA**" means the European Economic Area;
+- e) "**EEA**" means the European Economic Area;
 
-6. "**EU Data Protection Laws**" means EU Directive 95/46/EC, as transposed
+- f) "**EU Data Protection Laws**" means EU Directive 95/46/EC, as transposed
    into domestic legislation of each Member State, and as amended,
    replaced, or superseded from time to time, including by the GDPR and
    laws implementing or supplementing the GDPR;
 
-7. "**GDPR**" means EU General Data Protection Regulation 2016/679;
+- g) "**GDPR**" means EU General Data Protection Regulation 2016/679;
 
-8. "**FADP**" means Federal Act on Data Protection of the 25th of September
+- h) "**FADP**" means Federal Act on Data Protection of the 25th of September
    2020 (FADP; RS 235.1)
 
-9. "**Data Transfer**" means a transfer of Company Personal Data from
+- i) "**Data Transfer**" means a transfer of Company Personal Data from
    Controller to the Processor or a Contracted Processor; or an onward
    transfer of Company Personal Data from the Processor to a Contracted
    Processor, or between two establishments of Processor or Contracted
    Processor;
 
-10. "**Services**" means online services provided by the Processor, as
+- j) "**Services**" means online services provided by the Processor, as
     described at Exoscale's Website, consumed by Company excluding third
     Party services available from the Exoscale's Marketplace. The
     purpose is the provision of the Services initiated by Company;
 
-11. "**Subprocessor**" means any person appointed by or on behalf of
+- k) "**Subprocessor**" means any person appointed by or on behalf of
     Processor to process Personal Data on behalf of Controller in
     connection with the Agreement.
 
@@ -105,22 +101,22 @@ construed accordingly.
 
 2.1 Processor shall:
 
-1. comply with all applicable Data Protection Laws in the Processing of
+- a) comply with all applicable Data Protection Laws in the Processing of
    Company Personal Data;
 
-2. not process Company Personal Data other than on Controller's
+- b) not process Company Personal Data other than on Controller's
    documented instructions.
 
 2.2 Controller instructs Processor to process Company Personal Data to:
 
-1. provide the Services and related technical support;
+- a) provide the Services and related technical support;
 
-2. fulfil legal obligations or resolve disputes;
+- b) fulfil legal obligations or resolve disputes;
 
-3. exercise any internal task aimed to optimize the security, privacy,
+- c) exercise any internal task aimed to optimize the security, privacy,
    confidentiality, and functionalities of the Services;
 
-4. exercise internal reporting, financial reporting, and other similar
+- d) exercise internal reporting, financial reporting, and other similar
    internal tasks.
 
 ## 3. Processor Personnel
@@ -146,16 +142,16 @@ minimize the risk of a Personal Data Breach.
 
 These measures include:
 
-1. the pseudonymization and encryption of Company Data;
+- a) the pseudonymization and encryption of Company Data;
 
-2. the ability to ensure the ongoing confidentiality, integrity,
+- b) the ability to ensure the ongoing confidentiality, integrity,
    availability, and resilience of Processing Services;
 
-3. the ability to restore the availability and access to Company
+- c) the ability to restore the availability and access to Company
    Personal Data in a timely manner in the event of a physical or
    technical incident;
 
-4. a process for regularly testing, assessing, and evaluating the
+- d) a process for regularly testing, assessing, and evaluating the
    effectiveness of technical and organizational measures for ensuring
    the security of the Processing.
 
@@ -198,11 +194,11 @@ exercise Data Subject rights under applicable Data Protection Laws.
 
 **Processor shall:**
 
-1. promptly notify Company if it receives a request from a Data Subject
+- a) promptly notify Company if it receives a request from a Data Subject
    under any Data Protection Law in respect of Company Personal Data;
    and
 
-2. ensure that it does not respond to that request except on the
+- b) ensure that it does not respond to that request except on the
    documented instructions of Controller or as required by applicable
    laws to which the Processor is subject, in which case Processor
    shall to the extent permitted by applicable laws inform Controller
@@ -319,9 +315,9 @@ Agreement ("Confidential Information") confidential and must not use or
 disclose that Confidential Information without the prior written consent
 of the other Party except to the extent that:
 
-1. disclosure is required by law;
+- a) disclosure is required by law;
 
-2. the relevant information is already in the public domain through no
+- b) the relevant information is already in the public domain through no
    fault of the Parties.
 
 **12.3 Notices:** All notices and communications given under this

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -18,8 +18,7 @@ WHEREAS
 
 (B) The Company wishes to subcontract certain Services, which imply the processing of personal data, to the Data Processor.
 
-(C) The Parties seek to implement a data processing agreement that complies with the requirements of the current legal framework in relation to data processing and with the Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation).
-
+(C) The Parties seek to implement a data processing agreement that complies with the requirements of the current legal framework in relation to data processing and with the Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation) and the Federal Act on Data Protection of 25 September 2020.
 (D) The Parties wish to lay down their rights and obligations.
 
 IT IS AGREED AS FOLLOWS:
@@ -42,15 +41,17 @@ IT IS AGREED AS FOLLOWS:
 
 1.1.7 “GDPR” means EU General Data Protection Regulation 2016/679;
 
-1.1.8 “Data Transfer” means:
+1.1.8 “FADP” means Federal Act on Data Protection of 25 September 2020 (FADP ; RS 235.1) 
 
-1.1.8.1 a transfer of Company Personal Data from the Company to a Contracted Processor; or
+1.1.9 “Data Transfer” means:
 
-1.1.8.2 an onward transfer of Company Personal Data from a Contracted Processor to a Subcontracted Processor, or between two establishments of a Contracted Processor, in each case, where such transfer would be prohibited by Data Protection Laws (or by the terms of data transfer agreements put in place to address the data transfer restrictions of Data Protection Laws);
+1.1.9.1 a transfer of Company Personal Data from the Company to a Contracted Processor; or
 
-1.1.9 “Services” means the services the Company provides as described in the Website by Client excluding third party services available from the Exoscale Marketplace. The purpose is the provision of the Services initiated by Client.
+1.1.9.2 an onward transfer of Company Personal Data from a Contracted Processor to a Subcontracted Processor, or between two establishments of a Contracted Processor, in each case, where such transfer would be prohibited by Data Protection Laws (or by the terms of data transfer agreements put in place to address the data transfer restrictions of Data Protection Laws);
 
-1.1.10 “Subprocessor” means any person appointed by or on behalf of Processor to process Personal Data on behalf of the Company in connection with the Agreement.
+1.1.10 “Services” means the services the Company provides as described in the Website by Client excluding third party services available from the Exoscale Marketplace. The purpose is the provision of the Services initiated by Client.
+
+1.1.11 “Subprocessor” means any person appointed by or on behalf of Processor to process Personal Data on behalf of the Company in connection with the Agreement.
 
 1.2 The terms, “Commission”, “Controller”, “Data Subject”, “Member State”, “Personal Data”, “Personal Data Breach”, “Processing” and “Supervisory Authority” shall have the same meaning as in the GDPR, and their cognate terms shall be construed accordingly.
 
@@ -109,32 +110,35 @@ Processor shall take reasonable steps to ensure the reliability of any employee,
 
 9.2 Client’s right to data return is described in Section 13 of the T&C. In addition, Processor deletes all the personal data after the end of the provision of Services and deletes existing copies unless Union or Member State law requires storage of the personal data.
 
-## 10. Audit rights
+## 10. Liability
 
-10.1 Subject to this section 10, Processor shall make available to the Company on request all information necessary to demonstrate compliance with this Agreement, and shall allow for and contribute to audits, including inspections, by the Company or an auditor mandated by the Company in relation to the Processing of the Company Personal Data by the Contracted Processors.
+The Processor shall indemnify Controller (and each of their respective officers, employees and agents) against all losses (including any claim, damage, cost, charge, fine, fees, levies, award, expense or other liability of any nature, whether direct, indirect, or consequential) arising out of or in connection with any failure by the Processor (and by any Subprocessor) to comply with the provisions of this Agreement or any Applicable Law.
+## 11. Audit rights
 
-10.2 Information and audit rights of the Company only arise under section 10.1 to the extent that the Agreement does not otherwise give them information and audit rights meeting the relevant requirements of Data Protection Law.
+11.1 Subject to this section 11, Processor shall make available to the Company on request all information necessary to demonstrate compliance with this Agreement, and shall allow for and contribute to audits, including inspections, by the Company or an auditor mandated by the Company in relation to the Processing of the Company Personal Data by the Contracted Processors.
 
-10.3 Processor allows for and contributes to audits, including inspections, to demonstrate compliance with the obligations and measures described in this DPA conducted by the Client or another auditor mandated by the Client by means of random checks during business hours, which are ordinarily to be announced 1 month in prior. In order to carry out an inspection, the Client shall send a detailed audit / control plan to Exoscale at least two weeks before the scheduled date of the audit, indicating the scope, duration of the audit and the start date of the audit. Exoscale shall review the audit/control plan and provide the Client with any material concerns and questions, such as information requests, that may affect the security, privacy or employment policy of the Exoscale. In any case, Exoscale cooperates cooperatively with the Client to agree on a final audit/control plan. Exoscale may claim remuneration for enabling Client inspections. Proof of the implementation of technical and organizational measures to comply with the obligations arising from this contract may be provided by:
+11.2 Information and audit rights of the Company only arise under section 11.1 to the extent that the Agreement does not otherwise give them information and audit rights meeting the relevant requirements of Data Protection Law.
+
+11.3 Processor allows for and contributes to audits, including inspections, to demonstrate compliance with the obligations and measures described in this DPA conducted by the Client or another auditor mandated by the Client by means of random checks during business hours, which are ordinarily to be announced 1 month in prior. In order to carry out an inspection, the Client shall send a detailed audit / control plan to Exoscale at least two weeks before the scheduled date of the audit, indicating the scope, duration of the audit and the start date of the audit. Exoscale shall review the audit/control plan and provide the Client with any material concerns and questions, such as information requests, that may affect the security, privacy or employment policy of the Exoscale. In any case, Exoscale cooperates cooperatively with the Client to agree on a final audit/control plan. Exoscale may claim remuneration for enabling Client inspections. Proof of the implementation of technical and organizational measures to comply with the obligations arising from this contract may be provided by:
 - a) Certification according to an approved certification procedure in accordance with Art.42 GDPR;
 - b) Current auditor’s certificates, reports or excerpts from reports provided by independent bodies (e.g. auditor, Data Protection Officer, IT security department, data privacy auditor, quality auditor)
 - c) A relevant certification by IT security or data protection auditing (e.g. according to IT Baseline Protection certification developed by the [German](https://en.wikipedia.org/wiki/Germany) Federal Office for Security in Information Technology (BSI)) or ISO/IEC).
 - d) Annual reports by Exoscale.
 
-## 11. Data Transfer
+## 12. Data Transfer
 
-11.1 The Processor may not transfer or authorize the transfer of Data to countries outside the EU and/or the European Economic Area (EEA) without the prior written consent of the Company. If personal data processed under this Agreement is transferred from a country within the European Economic Area to a country outside the European Economic Area, the Parties shall ensure that the personal data are adequately protected. To achieve this, the Parties shall, unless agreed otherwise, rely on EU approved standard contractual clauses for the transfer of personal data.
+12.1 The Processor may not transfer or authorize the transfer of Data to countries outside the EU and/or the European Economic Area (EEA) without the prior written consent of the Company. If personal data processed under this Agreement is transferred from a country within the European Economic Area to a country outside the European Economic Area, the Parties shall ensure that the personal data are adequately protected. To achieve this, the Parties shall, unless agreed otherwise, rely on EU approved standard contractual clauses for the transfer of personal data. To the extent possible, the Processor shall only transfer or authorize the transfer of Data to countries within Switzerland, the EU and/or countries subject to an adequacy decision, as provided for in art. 45 GDPR and art. 16 Swiss FADP.
 
-## 12. General Terms
+## 13. General Terms
 
-12.1 Confidentiality. Each Party must keep this Agreement and information it receives about the other Party and its business in connection with this Agreement (“Confidential Information”) confidential and must not use or disclose that Confidential Information without the prior written consent of the other Party except to the extent that:
+13.1 Confidentiality. Each Party must keep this Agreement and information it receives about the other Party and its business in connection with this Agreement (“Confidential Information”) confidential and must not use or disclose that Confidential Information without the prior written consent of the other Party except to the extent that:
 (a) disclosure is required by law;
 (b) the relevant information is already in the public domain.
 
-12.2 Notices. All notices and communications given under this Agreement must be in writing and will be delivered personally, sent by post or sent by email to the address or email address set out in the heading of this Agreement at such other address as notified from time to time by the Parties changing address.
+13.2 Notices. All notices and communications given under this Agreement must be in writing and will be delivered personally, sent by email to the address provided during account creation.
 
-## 13. Governing Law and Jurisdiction
+## 14. Governing Law and Jurisdiction
 
-13.1 This Agreement is governed by the laws of Switzerland.
+14.1 This Agreement is governed by the laws of Switzerland.
 
-13.2 Any dispute arising in connection with this Agreement, which the Parties will not be able to resolve amicably, will be submitted to the exclusive jurisdiction of the courts of _________________, subject to possible appeal to __________________________________.
+14.2 Any dispute arising in connection with this Agreement, which the Parties will not be able to resolve amicably, will be submitted to the exclusive jurisdiction of the courts of Lausanne, Switzerland.

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -1,6 +1,6 @@
 This Data Processing Addendum, hereafter "DPA", is an Agreement between
-Akenes SA hereafter "Exoscale" (referred to as the "**Processor**") and the client 
-hereafter "Client" (referred to as the "**Company**"). 
+Akenes SA hereafter "Exoscale" (referred to as the "**Processor**") and the client
+hereafter "Client" (referred to as the "**Company**").
 This Addendum is either an extension to the Exoscale Terms and Conditions
 available at <https://www.exoscale.com/terms/>, or the EUSA, as the case
 maybe, (each hereafter T&C) as updated from time to time between Client
@@ -48,7 +48,7 @@ IT IS AGREED AS FOLLOWS:
 
 1.1.8.2 an onward transfer of Company Personal Data from a Contracted Processor to a Subcontracted Processor, or between two establishments of a Contracted Processor, in each case, where such transfer would be prohibited by Data Protection Laws (or by the terms of data transfer agreements put in place to address the data transfer restrictions of Data Protection Laws);
 
-1.1.9 “Services” means the services the Company provides as described in the Website by Client excluding third party services available from the Exoscale Marketplace. The purpose is the provision of the Services initiated by Client..
+1.1.9 “Services” means the services the Company provides as described in the Website by Client excluding third party services available from the Exoscale Marketplace. The purpose is the provision of the Services initiated by Client.
 
 1.1.10 “Subprocessor” means any person appointed by or on behalf of Processor to process Personal Data on behalf of the Company in connection with the Agreement.
 
@@ -73,9 +73,16 @@ Processor shall take reasonable steps to ensure the reliability of any employee,
 
 4.2 In assessing the appropriate level of security, Processor shall take account in particular of the risks that are presented by Processing, in particular from a Personal Data Breach.
 
+4.3 These measures take into account the state of the art and include:
+- (a) the pseudonymisation and encryption of Client Data;
+- (b) the ability to ensure the ongoing confidentiality, integrity, availability and resilience of processing systems and services;
+- (c) the ability to restore the availability and access to personal data in a timely manner in the event of a physical or technical incident;
+- (d) a process for regularly testing, assessing and evaluating the effectiveness of technical and organizational measures for ensuring the security of the processing.
+
 ## 5. Subprocessing
 
 5.1 Processor shall not appoint (or disclose any Company Personal Data to) any Subprocessor unless required or authorized by the Company.
+
 5.2 Processor maintains a list of its sub-Processors per Service at https://www.exoscale.com/privacy/#data-processors. Processor informs the Company of any intended changes concerning the addition or replacement of other Processors at least 30 days in advance. Processor makes sure Data Processing Addendums are in place with its sub-Processors to ensure compliance with the GDPR and our security/data protection policies. If the Company objects the addition or replacement of a sub-Processor, they may terminate the services as described in the T&C.
 
 ## 6. Data Subject Rights
@@ -100,11 +107,19 @@ Processor shall take reasonable steps to ensure the reliability of any employee,
 
 9.1 Subject to this section 9 Processor shall promptly and in any event within 10 business days of the date of cessation of any Services involving the Processing of Company Personal Data (the “Cessation Date”), delete and procure the deletion of all copies of those Company Personal Data.
 
+9.2 Client’s right to data return is described in Section 13 of the T&C. In addition, Processor deletes all the personal data after the end of the provision of Services and deletes existing copies unless Union or Member State law requires storage of the personal data.
+
 ## 10. Audit rights
 
 10.1 Subject to this section 10, Processor shall make available to the Company on request all information necessary to demonstrate compliance with this Agreement, and shall allow for and contribute to audits, including inspections, by the Company or an auditor mandated by the Company in relation to the Processing of the Company Personal Data by the Contracted Processors.
 
 10.2 Information and audit rights of the Company only arise under section 10.1 to the extent that the Agreement does not otherwise give them information and audit rights meeting the relevant requirements of Data Protection Law.
+
+10.3 Processor allows for and contributes to audits, including inspections, to demonstrate compliance with the obligations and measures described in this DPA conducted by the Client or another auditor mandated by the Client by means of random checks during business hours, which are ordinarily to be announced 1 month in prior. In order to carry out an inspection, the Client shall send a detailed audit / control plan to Exoscale at least two weeks before the scheduled date of the audit, indicating the scope, duration of the audit and the start date of the audit. Exoscale shall review the audit/control plan and provide the Client with any material concerns and questions, such as information requests, that may affect the security, privacy or employment policy of the Exoscale. In any case, Exoscale cooperates cooperatively with the Client to agree on a final audit/control plan. Exoscale may claim remuneration for enabling Client inspections. Proof of the implementation of technical and organizational measures to comply with the obligations arising from this contract may be provided by:
+- a) Certification according to an approved certification procedure in accordance with Art.42 GDPR;
+- b) Current auditor’s certificates, reports or excerpts from reports provided by independent bodies (e.g. auditor, Data Protection Officer, IT security department, data privacy auditor, quality auditor)
+- c) A relevant certification by IT security or data protection auditing (e.g. according to IT Baseline Protection certification developed by the [German](https://en.wikipedia.org/wiki/Germany) Federal Office for Security in Information Technology (BSI)) or ISO/IEC).
+- d) Annual reports by Exoscale.
 
 ## 11. Data Transfer
 
@@ -123,5 +138,3 @@ Processor shall take reasonable steps to ensure the reliability of any employee,
 13.1 This Agreement is governed by the laws of Switzerland.
 
 13.2 Any dispute arising in connection with this Agreement, which the Parties will not be able to resolve amicably, will be submitted to the exclusive jurisdiction of the courts of _________________, subject to possible appeal to __________________________________.
-
-

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -24,7 +24,7 @@ WHEREAS
 
 IT IS AGREED AS FOLLOWS:
 
-1. Definitions and Interpretation
+## 1. Definitions and Interpretation
 
 1.1 Unless otherwise defined herein, capitalized terms and expressions used in this Agreement shall have the following meaning:
 
@@ -54,7 +54,7 @@ IT IS AGREED AS FOLLOWS:
 
 1.2 The terms, “Commission”, “Controller”, “Data Subject”, “Member State”, “Personal Data”, “Personal Data Breach”, “Processing” and “Supervisory Authority” shall have the same meaning as in the GDPR, and their cognate terms shall be construed accordingly.
 
-2. Processing of Company Personal Data
+## 2. Processing of Company Personal Data
 
 2.1 Processor shall:
 
@@ -64,21 +64,21 @@ IT IS AGREED AS FOLLOWS:
 
 2.2 The Company instructs Processor to process Company Personal Data.
 
-3. Processor Personnel
+## 3. Processor Personnel
 Processor shall take reasonable steps to ensure the reliability of any employee, agent or contractor of any Contracted Processor who may have access to the Company Personal Data, ensuring in each case that access is strictly limited to those individuals who need to know / access the relevant Company Personal Data, as strictly necessary for the purposes of the Principal Agreement, and to comply with Applicable Laws in the context of that individual’s duties to the Contracted Processor, ensuring that all such individuals are subject to confidentiality undertakings or professional or statutory obligations of confidentiality.
 
-4. Security
+## 4. Security
 
 4.1 Taking into account the state of the art, the costs of implementation and the nature, scope, context and purposes of Processing as well as the risk of varying likelihood and severity for the rights and freedoms of natural persons, Processor shall in relation to the Company Personal Data implement appropriate technical and organizational measures to ensure a level of security appropriate to that risk, including, as appropriate, the measures referred to in Article 32(1) of the GDPR.
 
 4.2 In assessing the appropriate level of security, Processor shall take account in particular of the risks that are presented by Processing, in particular from a Personal Data Breach.
 
-5. Subprocessing
+## 5. Subprocessing
 
 5.1 Processor shall not appoint (or disclose any Company Personal Data to) any Subprocessor unless required or authorized by the Company.
 5.2 Processor maintains a list of its sub-Processors per Service at https://www.exoscale.com/privacy/#data-processors. Processor informs the Company of any intended changes concerning the addition or replacement of other Processors at least 30 days in advance. Processor makes sure Data Processing Addendums are in place with its sub-Processors to ensure compliance with the GDPR and our security/data protection policies. If the Company objects the addition or replacement of a sub-Processor, they may terminate the services as described in the T&C.
 
-6. Data Subject Rights
+## 6. Data Subject Rights
 
 6.1 Taking into account the nature of the Processing, Processor shall assist the Company by implementing appropriate technical and organisational measures, insofar as this is possible, for the fulfilment of the Company obligations, as reasonably understood by Company, to respond to requests to exercise Data Subject rights under the Data Protection Laws.
 
@@ -88,29 +88,29 @@ Processor shall take reasonable steps to ensure the reliability of any employee,
 
 6.2.2 ensure that it does not respond to that request except on the documented instructions of Company or as required by Applicable Laws to which the Processor is subject, in which case Processor shall to the extent permitted by Applicable Laws inform Company of that legal requirement before the Contracted Processor responds to the request.
 
-7. Personal Data Breach
+## 7. Personal Data Breach
 
 7.1 Processor shall notify Company without undue delay upon Processor becoming aware of a Personal Data Breach affecting Company Personal Data, providing Company with sufficient information to allow the Company to meet any obligations to report or inform Data Subjects of the Personal Data Breach under the Data Protection Laws.
 
 7.2 Processor shall co-operate with the Company and take reasonable commercial steps as are directed by Company to assist in the investigation, mitigation and remediation of each such Personal Data Breach.
 
-8. Data Protection Impact Assessment and Prior Consultation Processor shall provide reasonable assistance to the Company with any data protection impact assessments, and prior consultations with Supervising Authorities or other competent data privacy authorities, which Company reasonably considers to be required by article 35 or 36 of the GDPR or equivalent provisions of any other Data Protection Law, in each case solely in relation to Processing of Company Personal Data by, and taking into account the nature of the Processing and information available to, the Contracted Processors.
+## 8. Data Protection Impact Assessment and Prior Consultation Processor shall provide reasonable assistance to the Company with any data protection impact assessments, and prior consultations with Supervising Authorities or other competent data privacy authorities, which Company reasonably considers to be required by article 35 or 36 of the GDPR or equivalent provisions of any other Data Protection Law, in each case solely in relation to Processing of Company Personal Data by, and taking into account the nature of the Processing and information available to, the Contracted Processors.
 
-9. Deletion or return of Company Personal Data
+## 9. Deletion or return of Company Personal Data
 
 9.1 Subject to this section 9 Processor shall promptly and in any event within 10 business days of the date of cessation of any Services involving the Processing of Company Personal Data (the “Cessation Date”), delete and procure the deletion of all copies of those Company Personal Data.
 
-10. Audit rights
+## 10. Audit rights
 
 10.1 Subject to this section 10, Processor shall make available to the Company on request all information necessary to demonstrate compliance with this Agreement, and shall allow for and contribute to audits, including inspections, by the Company or an auditor mandated by the Company in relation to the Processing of the Company Personal Data by the Contracted Processors.
 
 10.2 Information and audit rights of the Company only arise under section 10.1 to the extent that the Agreement does not otherwise give them information and audit rights meeting the relevant requirements of Data Protection Law.
 
-11. Data Transfer
+## 11. Data Transfer
 
 11.1 The Processor may not transfer or authorize the transfer of Data to countries outside the EU and/or the European Economic Area (EEA) without the prior written consent of the Company. If personal data processed under this Agreement is transferred from a country within the European Economic Area to a country outside the European Economic Area, the Parties shall ensure that the personal data are adequately protected. To achieve this, the Parties shall, unless agreed otherwise, rely on EU approved standard contractual clauses for the transfer of personal data.
 
-12. General Terms
+## 12. General Terms
 
 12.1 Confidentiality. Each Party must keep this Agreement and information it receives about the other Party and its business in connection with this Agreement (“Confidential Information”) confidential and must not use or disclose that Confidential Information without the prior written consent of the other Party except to the extent that:
 (a) disclosure is required by law;
@@ -118,7 +118,7 @@ Processor shall take reasonable steps to ensure the reliability of any employee,
 
 12.2 Notices. All notices and communications given under this Agreement must be in writing and will be delivered personally, sent by post or sent by email to the address or email address set out in the heading of this Agreement at such other address as notified from time to time by the Parties changing address.
 
-13. Governing Law and Jurisdiction
+## 13. Governing Law and Jurisdiction
 
 13.1 This Agreement is governed by the laws of Switzerland.
 

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -158,10 +158,9 @@ These measures include:
 4.2 The Processor continues to adjust technical and organizational
 measures to follow latest versions of security frameworks and comply
 with most recent revisions of internationally recognized security and
-privacy certifications as found at ﷟HYPERLINK
-<https://www.exoscale.com/compliance>. These certifications are to
-demonstrate compliance with the requirements set out in section 4.1 of
-this Agreement, as proposed in Article 32 (3) GDPR.
+privacy certifications as found at https://www.exoscale.com/compliance. 
+These certifications are to demonstrate compliance with the requirements 
+set out in section 4.1 of this Agreement, as proposed in Article 32 (3) GDPR.
 
 ## 5. Subprocessing
 

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -41,7 +41,7 @@ IT IS AGREED AS FOLLOWS:
 
 1.1.7 “GDPR” means EU General Data Protection Regulation 2016/679;
 
-1.1.8 “FADP” means Federal Act on Data Protection of 25 September 2020 (FADP ; RS 235.1) 
+1.1.8 “FADP” means Federal Act on Data Protection of 25 September 2020 (FADP ; RS 235.1)
 
 1.1.9 “Data Transfer” means:
 

--- a/dpa.markdown
+++ b/dpa.markdown
@@ -27,13 +27,13 @@ account at Exoscale.
 
 **WHEREAS**
 
-- a) The Company acts as a Data Controller (the "Controller").
+1. The Company acts as a Data Controller (the "Controller").
 
-- b) The Company wishes to subcontract certain Services (as defined
+2. The Company wishes to subcontract certain Services (as defined
    below), which imply the processing of Personal Data, to Exoscale,
    acting as a Data Processor (the "Processor").
 
-- c) The Parties seek to implement a data processing agreement that
+3. The Parties seek to implement a data processing agreement that
    complies with the requirements of the current legal framework in
    relation to data processing and with the Regulation (EU) 2016/679 of
    the European Parliament and of the Council of 27 April 2016 on the
@@ -43,7 +43,7 @@ account at Exoscale.
    Swiss Federal Act on Data Protection of 25 September 2020 (FADP; RS
    235.1) and other applicable data protection laws.
 
-- d) The Parties wish to lay down their rights and obligations.
+4. The Parties wish to lay down their rights and obligations.
 
 **IT IS AGREED AS FOLLOWS:**
 
@@ -52,42 +52,42 @@ account at Exoscale.
 Unless otherwise defined herein, capitalized terms and expressions used
 in this Agreement shall have the following meaning:
 
-- a) "**Agreement**" means this Data Processing Addendum and all Schedules;
+1. "**Agreement**" means this Data Processing Addendum and all Schedules;
 
-- b) "**Company Personal Data**" means any Personal Data related to the
+2. "**Company Personal Data**" means any Personal Data related to the
    Company or Company's customers or employees processed in connection
    with the Principal Agreements;
 
-- c) "**Contracted Processor**" means a Subprocessor;
+3. "**Contracted Processor**" means a Subprocessor;
 
-- d) "**Data Protection Laws**" means EU Data Protection Laws and, to the
+4. "**Data Protection Laws**" means EU Data Protection Laws and, to the
    extent applicable, the data protection or privacy laws of any other
    country;
 
-- e) "**EEA**" means the European Economic Area;
+5. "**EEA**" means the European Economic Area;
 
-- f) "**EU Data Protection Laws**" means EU Directive 95/46/EC, as transposed
+6. "**EU Data Protection Laws**" means EU Directive 95/46/EC, as transposed
    into domestic legislation of each Member State, and as amended,
    replaced, or superseded from time to time, including by the GDPR and
    laws implementing or supplementing the GDPR;
 
-- g) "**GDPR**" means EU General Data Protection Regulation 2016/679;
+7. "**GDPR**" means EU General Data Protection Regulation 2016/679;
 
-- h) "**FADP**" means Federal Act on Data Protection of the 25th of September
+8. "**FADP**" means Federal Act on Data Protection of the 25th of September
    2020 (FADP; RS 235.1)
 
-- i) "**Data Transfer**" means a transfer of Company Personal Data from
+9. "**Data Transfer**" means a transfer of Company Personal Data from
    Controller to the Processor or a Contracted Processor; or an onward
    transfer of Company Personal Data from the Processor to a Contracted
    Processor, or between two establishments of Processor or Contracted
    Processor;
 
-- j) "**Services**" means online services provided by the Processor, as
+10. "**Services**" means online services provided by the Processor, as
     described at Exoscale's Website, consumed by Company excluding third
     Party services available from the Exoscale's Marketplace. The
     purpose is the provision of the Services initiated by Company;
 
-- k) "**Subprocessor**" means any person appointed by or on behalf of
+11. "**Subprocessor**" means any person appointed by or on behalf of
     Processor to process Personal Data on behalf of Controller in
     connection with the Agreement.
 
@@ -99,24 +99,28 @@ construed accordingly.
 
 ## 2. Processing of Company Personal Data
 
-2.1 Processor shall:
+### 2.1. Processor obligations
 
-- a) comply with all applicable Data Protection Laws in the Processing of
+Processor shall:
+
+1. comply with all applicable Data Protection Laws in the Processing of
    Company Personal Data;
 
-- b) not process Company Personal Data other than on Controller's
+2. not process Company Personal Data other than on Controller's
    documented instructions.
 
-2.2 Controller instructs Processor to process Company Personal Data to:
+### 2.2 Controller instructions
 
-- a) provide the Services and related technical support;
+Controller instructs Processor to process Company Personal Data to:
 
-- b) fulfil legal obligations or resolve disputes;
+1. provide the Services and related technical support;
 
-- c) exercise any internal task aimed to optimize the security, privacy,
+2. fulfil legal obligations or resolve disputes;
+
+3. exercise any internal task aimed to optimize the security, privacy,
    confidentiality, and functionalities of the Services;
 
-- d) exercise internal reporting, financial reporting, and other similar
+4. exercise internal reporting, financial reporting, and other similar
    internal tasks.
 
 ## 3. Processor Personnel
@@ -133,7 +137,9 @@ obligations of confidentiality.
 
 ## 4. Security
 
-4.1 In accordance with Article 32 (1) of the GDPR, the Processor shall
+### 4.1. Technical and Organizational measures
+
+In accordance with Article 32 (1) of the GDPR, the Processor shall
 implement technical and organizational measures to ensure a level of
 security appropriate to the risk, considering the state of the art, the
 costs of implementation, and the nature, scope, context, and purposes of
@@ -142,29 +148,33 @@ minimize the risk of a Personal Data Breach.
 
 These measures include:
 
-- a) the pseudonymization and encryption of Company Data;
+1. the pseudonymization and encryption of Company Data;
 
-- b) the ability to ensure the ongoing confidentiality, integrity,
+2. the ability to ensure the ongoing confidentiality, integrity,
    availability, and resilience of Processing Services;
 
-- c) the ability to restore the availability and access to Company
+3. the ability to restore the availability and access to Company
    Personal Data in a timely manner in the event of a physical or
    technical incident;
 
-- d) a process for regularly testing, assessing, and evaluating the
+4. a process for regularly testing, assessing, and evaluating the
    effectiveness of technical and organizational measures for ensuring
    the security of the Processing.
 
-4.2 The Processor continues to adjust technical and organizational
+### 4.2. Certifications
+
+The Processor continues to adjust technical and organizational
 measures to follow latest versions of security frameworks and comply
 with most recent revisions of internationally recognized security and
-privacy certifications as found at https://www.exoscale.com/compliance. 
-These certifications are to demonstrate compliance with the requirements 
+privacy certifications as found at https://www.exoscale.com/compliance.
+These certifications are to demonstrate compliance with the requirements
 set out in section 4.1 of this Agreement, as proposed in Article 32 (3) GDPR.
 
 ## 5. Subprocessing
 
-5.1 Processor shall not appoint (or disclose any Company Personal Data
+### 5.1. Appointment of Subprocessors
+
+Processor shall not appoint (or disclose any Company Personal Data
 to) any Subprocessor unless authorized by the Company. The Company
 acknowledges and approves the following list of Subprocessors:
 
@@ -179,7 +189,9 @@ days in advance. If Company objects the addition or replacement of a
 Subprocessor, it may terminate the Services upon 30 (thirty) days
 notice.
 
-5.2 Processor ensures that Subprocessors are subject to an agreement
+### 5.2. Agreements with Subprocessors
+
+Processor ensures that Subprocessors are subject to an agreement
 with Processor no less restrictive and protective than the present
 Agreement with respect to the protection of Company Personal Data to the
 extent applicable to the nature of the Services provided by the
@@ -193,11 +205,11 @@ exercise Data Subject rights under applicable Data Protection Laws.
 
 **Processor shall:**
 
-- a) promptly notify Company if it receives a request from a Data Subject
+1. promptly notify Company if it receives a request from a Data Subject
    under any Data Protection Law in respect of Company Personal Data;
    and
 
-- b) ensure that it does not respond to that request except on the
+2. ensure that it does not respond to that request except on the
    documented instructions of Controller or as required by applicable
    laws to which the Processor is subject, in which case Processor
    shall to the extent permitted by applicable laws inform Controller
@@ -206,7 +218,9 @@ exercise Data Subject rights under applicable Data Protection Laws.
 
 ## 7. Personal Data Breach
 
-7.1 The Processor shall manage any Personal Data Breach in compliance
+### 7.1. Data breach process
+
+The Processor shall manage any Personal Data Breach in compliance
 with applicable Data Protection Laws and its internal Personal Data
 Breach procedures. In the event of a Personal Data Breach affecting
 Company Personal Data, the Processor shall notify the Company without
@@ -217,7 +231,9 @@ Company with sufficient information to allow the Company to meet any
 obligations to report or inform Data Subjects of the Personal Data
 Breach under the Data Protection Laws.
 
-7.2 Processor shall co-operate with the Company and take reasonable
+### 7.2. Co-operation
+
+Processor shall co-operate with the Company and take reasonable
 commercial steps as directed by the Company to assist in the
 investigation, mitigation, and remediation of each such Personal Data
 Breach.
@@ -235,18 +251,24 @@ the Contracted Processors.
 
 ## 9. Deletion or Return of Company Personal Data
 
-9.1 In case of cessation of any Service involving the Processing of
+### 9.1. Service termination
+
+In case of cessation of any Service involving the Processing of
 Company Personal Data, the Processor shall delete all Company Personal
 Data. Should the Company require a copy of their data, they must request
 it before the deletion of their account; requests made after the account
 has been deleted can no longer be considered.
 
-9.2 Upon request of Company, notified at least 30 (thirty) days prior to
+### 9.2. Data return
+
+Upon request of Company, notified at least 30 (thirty) days prior to
 termination of the Services, Processor shall make Company Data available
 to Company in its original format through the Processor's recovery
 service, upon charge of a recovery service fee.
 
-9.3 Unless a request for the Processor's recovery service is made,
+### 9.3. Deletion
+
+Unless a request for the Processor's recovery service is made,
 Processor shall have no obligation to maintain or provide any of Company
 Data after termination of the Services and shall thereafter, unless
 legally prohibited, promptly and in any event within 10 (ten) business
@@ -256,7 +278,9 @@ deletion of all copies of those Company Personal Data.
 
 ## 10. Audit Rights
 
-10.1 Subject to this section 10, Processor shall make available to
+### 10.1. Audit process
+
+Subject to this section 10, Processor shall make available to
 Company on request all information necessary to demonstrate compliance
 with this Agreement, and shall allow for and contribute to audits,
 including inspections, by Company or an auditor mandated by Company in
@@ -267,7 +291,9 @@ an instruction by a regulatory authority. Company shall give Processor
 at least 60 (sixty) days prior written notice of its intention to audit
 Processor pursuant to this Agreement.
 
-10.2 Audit shall be conducted during Processor's business hours, shall
+### 10.2. Limitations
+
+Audit shall be conducted during Processor's business hours, shall
 not disrupt Processor's operations, and shall ensure the protection of
 the Company's, Processor's, and other Data Subjects' Personal Data.
 Processor and Company shall mutually agree in advance on the date,
@@ -275,17 +301,23 @@ scope, duration, and security and confidentiality controls applicable to
 the audit. Company acknowledges that signing a non-disclosure agreement
 may be required by the Controller prior to the audit.
 
-10.3 Information and audit rights of Company only arise under section 10
+### 10.3. Scope
+
+Information and audit rights of Company only arise under section 10
 to the extent that the Agreement does not otherwise give them
 information and audit rights meeting the relevant requirements of Data
 Protection Law.
 
 ## 11. Data Transfer
 
-11.1 Processor shall not transfer any Company Data, including Company
+### 11.1. Data transfer between countries
+
+Processor shall not transfer any Company Data, including Company
 Personal Data, between countries unless authorized by Company.
 
-11.2 Processor shall only transfer or authorize the transfer of Data
+### 11.2. Data protection across jurisdictions
+
+Processor shall only transfer or authorize the transfer of Data
 within Switzerland, the EU, the EEA, and/or countries subject to an
 adequacy decision, as provided for in art. 45 GDPR and art. 16 Swiss
 FADP. If Personal Data processed under this Agreement is transferred
@@ -302,30 +334,38 @@ transfer.
 
 ## 12. General Terms
 
-**12.1 Compliance with Applicable Laws:** Processor will process Company
+### 12.1. Compliance with Applicable Laws
+
+Processor will process Company
 Personal Data in accordance with this Agreement and Data Protection Laws
 applicable to its role under this Agreement. Processor is not
 responsible nor liable for complying with Data Protection Laws solely
 applicable to Company by virtue of its business or industry.
 
-**12.2 Confidentiality:** Each Party must keep any information it
+### 12.2. Confidentiality
+
+Each Party must keep any information it
 receives about the other Party and its business in connection with this
 Agreement ("Confidential Information") confidential and must not use or
 disclose that Confidential Information without the prior written consent
 of the other Party except to the extent that:
 
-- a) disclosure is required by law;
+1. disclosure is required by law;
 
-- b) the relevant information is already in the public domain through no
+2. the relevant information is already in the public domain through no
    fault of the Parties.
 
-**12.3 Notices:** All notices and communications given under this
+### 12.3. Notices
+
+All notices and communications given under this
 Agreement must be in writing and will be sent by email. Controller shall
 be notified by email sent to the address related to its use of the
 Services under the Principal Agreements. Processor shall be notified by
 email sent to the address: privacy@exoscale.com.
 
-**12.4 Governing Law and Jurisdiction:** This Agreement shall be
+### 12.4. Governing Law and Jurisdiction
+
+This Agreement shall be
 governed by Swiss law, without regard to the choice or conflicts of law
 provisions of any jurisdiction to the contrary, and disputes, actions,
 claims or causes of action arising out of or in connection with this


### PR DESCRIPTION
In response to customer feedback and for a better readability we have released a new version of our DPA. Major changes include: 
 
- Explicit commitment to comply with Swiss Federal Act on Data Protection (FADP) of 25th September 2020.
- For increased transparency, relevant information from General Terms and Conditions and Privacy Policy is now included instead of referenced.
- Removed Schedule 1 (Security Controls) and referenced approved certifications instead as proposed by GDPR 32 (3).
- Consistent terminology.